### PR TITLE
Added Frigate Labels & Sub_Labels

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "*.yaml": "home-assistant"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
     "files.associations": {
         "*.yaml": "home-assistant"
-    }
+    },
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "main"
+    ]
 }

--- a/blueprints/event_summary.yaml
+++ b/blueprints/event_summary.yaml
@@ -204,12 +204,12 @@ variables:
   label: >
     {% if mode == 'Frigate' %}
       {% if trigger.payload_json['after']['sub_label'] %}
-        {{trigger.payload_json['after']['sub_label'][0]|capitalize}} seen
+        {{trigger.payload_json['after']['sub_label'][0]|capitalize}} bei {{trigger.payload_json['after']['camera']}} erkannt
       {% else %}
-        {{ trigger.payload_json['after']['label']|capitalize }} seen
+        {{ trigger.payload_json['after']['label']|capitalize }} bei {{trigger.payload_json['after']['camera']}} erkannt
       {% endif %}
     {% else %}
-      Motion detected
+      Bewegung bei {{trigger.payload_json['after']['camera']}} erkannt
     {% endif %}
   camera: >
     {% if mode == 'Frigate' %}

--- a/blueprints/event_summary.yaml
+++ b/blueprints/event_summary.yaml
@@ -279,11 +279,6 @@ action:
                   - condition: template
                     value_template: "{{ mode == 'Frigate'}}"
                 sequence:
-                  - delay:
-                      hours: 0
-                      minutes: 0
-                      seconds: 5
-                      milliseconds: 0
                   - service: llmvision.image_analyzer
                     data:
                       image_entity: "{{ ['camera.' + trigger.payload_json['after']['camera']|lower] }}"
@@ -347,11 +342,7 @@ action:
           - condition: template
             value_template: "{{ mode == 'Frigate' }}"
         sequence:
-          - delay:
-              hours: 0
-              minutes: 0
-              seconds: 5
-              milliseconds: 0
+          - delay: "00:00:05"
           - service: llmvision.video_analyzer
             data:
               event_id: "{{ trigger.payload_json['after']['id'] }}"
@@ -370,6 +361,7 @@ action:
           - condition: template
             value_template: "{{ mode == 'Camera' }}"
         sequence:
+          - delay: "00:00:05"
           - service: llmvision.stream_analyzer
             data:
               image_entity: "{{[camera_entity]}}"

--- a/blueprints/event_summary.yaml
+++ b/blueprints/event_summary.yaml
@@ -1,6 +1,6 @@
 blueprint:
-  name: AI Event Summary (LLM Vision v1.3)
-  author: valentinfrlch
+  name: AI Event Summary - bullitt168 fork from valentinfrlch
+  author: bullitt168
   description: >
     AI-powered security event summaries for frigate or camera entities. 
     Sends a notification with a preview to your phone that is updated dynamically when the AI summary is available.

--- a/blueprints/event_summary.yaml
+++ b/blueprints/event_summary.yaml
@@ -212,9 +212,9 @@ variables:
   label: >
     {% if mode == 'Frigate' %}
       {% if event['after']['sub_label'] and update_sub_label %} 
-        {{event['after']['sub_label'][0]|capitalize}} seen
+        {{event['after']['sub_label']|capitalize}} seen
       {% elif trigger.payload_json['after']['label'] %}      
-        {{ trigger.payload_json['after']['label'][0]|capitalize}} seen
+        {{ trigger.payload_json['after']['label']|capitalize}} seen
       {% else %}
         Motion detected
       {% endif %}

--- a/blueprints/event_summary.yaml
+++ b/blueprints/event_summary.yaml
@@ -61,8 +61,8 @@ blueprint:
       name: Update Sub Label (Advanced)
       description: |
         Update the title and/or message with the matched face name and trigger a notification update. 
-        Requires face detection to be configured (Advanced). Requires Title and/or Message to contain 'A Person' or 'A {{ label }}'
-      default: true
+        Requires face detection in Frigate to be configured.
+      default: false
       selector:
         boolean:
     preview_mode:

--- a/blueprints/event_summary.yaml
+++ b/blueprints/event_summary.yaml
@@ -212,7 +212,7 @@ variables:
   label: >
     {% if mode == 'Frigate' %}
       {% if event['after']['sub_label'] and update_sub_label %} 
-        {{event['after']['sub_label']|capitalize}} seen
+        {{event['after']['sub_label'][0]|capitalize}} seen
       {% elif trigger.payload_json['after']['label'] %}      
         {{ trigger.payload_json['after']['label']|capitalize}} seen
       {% else %}

--- a/blueprints/event_summary.yaml
+++ b/blueprints/event_summary.yaml
@@ -202,7 +202,11 @@ variables:
     {% endif %}
   label: >
     {% if mode == 'Frigate' %}
-      {{ trigger.payload_json['after']['label']|capitalize }} seen
+      {% if trigger.payload_json['after']['sub_label'] %}
+        {{trigger.payload_json['after']['sub_label'][0]|capitalize}} seen
+      {% else %}
+        {{ trigger.payload_json['after']['label']|capitalize }} seen
+      {% endif %}
     {% else %}
       Motion detected
     {% endif %}

--- a/blueprints/event_summary.yaml
+++ b/blueprints/event_summary.yaml
@@ -42,9 +42,9 @@ blueprint:
           filter:
             domain: camera
     labels:
-      name: Object Filter (Frigate mode only)
+      name: Object Filter
       description: |
-        Specify objects you wish to be notified about. Enter or select one object at a time.
+        (Frigate mode only) Specify objects you wish to be notified about. Enter or select one object at a time.
       default: ""
       selector:
         select:

--- a/blueprints/event_summary.yaml
+++ b/blueprints/event_summary.yaml
@@ -41,6 +41,22 @@ blueprint:
           multiple: true
           filter:
             domain: camera
+    labels:
+      name: Object Filter (Frigate mode only)
+      description: |
+        Specify objects you wish to be notified about. Enter or select one object at a time.
+      default: ""
+      selector:
+        select:
+          options:
+            - person
+            - dog
+            - cat
+            - car
+            - package
+            - bird
+          multiple: true
+          custom_value: true
     preview_mode:
       name: Preview Mode
       description: (Camera mode only) Choose between a live preview or a snapshot of the event
@@ -159,6 +175,8 @@ variables:
   preview_mode: !input preview_mode
   camera_entities_list: !input camera_entities
   motion_sensors_list: !input motion_sensors
+  input_labels: !input labels
+  frigate_labels: "{{ input_labels | list | lower }}"
   camera_entity: >
     {% if mode == 'Camera' %}
       {% if motion_sensors_list %}
@@ -232,7 +250,7 @@ condition:
   - condition: template
     value_template: >
       {% if mode == 'Frigate' %}
-        {{ trigger.payload_json["type"] == "end" and (state_attr(this.entity_id, 'last_triggered') is none or (now() - state_attr(this.entity_id, 'last_triggered')).total_seconds() / 60 > cooldown) and ('camera.' + trigger.payload_json['after']['camera']|lower) in camera_entities_list }}
+        {{ trigger.payload_json["type"] == "end" and (state_attr(this.entity_id, 'last_triggered') is none or (now() - state_attr(this.entity_id, 'last_triggered')).total_seconds() / 60 > cooldown) and ('camera.' + trigger.payload_json['after']['camera']|lower) in camera_entities_list and (not frigate_labels|length or trigger.payload_json['after']['label'] in frigate_labels) }}
       {% else %}
         {{ state_attr(this.entity_id, 'last_triggered') is none or (now() - state_attr(this.entity_id, 'last_triggered')).total_seconds() / 60 > cooldown }}
       {% endif %}

--- a/blueprints/event_summary.yaml
+++ b/blueprints/event_summary.yaml
@@ -280,10 +280,10 @@ action:
                     value_template: "{{ mode == 'Frigate'}}"
                 sequence:
                   - delay:
-                    hours: 0
-                    minutes: 0
-                    seconds: 5
-                    milliseconds: 0
+                      hours: 0
+                      minutes: 0
+                      seconds: 5
+                      milliseconds: 0
                   - service: llmvision.image_analyzer
                     data:
                       image_entity: "{{ ['camera.' + trigger.payload_json['after']['camera']|lower] }}"
@@ -348,10 +348,10 @@ action:
             value_template: "{{ mode == 'Frigate' }}"
         sequence:
           - delay:
-            hours: 0
-            minutes: 0
-            seconds: 5
-            milliseconds: 0
+              hours: 0
+              minutes: 0
+              seconds: 5
+              milliseconds: 0
           - service: llmvision.video_analyzer
             data:
               event_id: "{{ trigger.payload_json['after']['id'] }}"

--- a/blueprints/event_summary.yaml
+++ b/blueprints/event_summary.yaml
@@ -176,6 +176,7 @@ variables:
   camera_entities_list: !input camera_entities
   motion_sensors_list: !input motion_sensors
   input_labels: !input labels
+  input_message: !input message
   frigate_labels: "{{ input_labels | list | lower }}"
   camera_entity: >
     {% if mode == 'Camera' %}
@@ -236,6 +237,12 @@ variables:
     Your job is to decide whether a camera recording is important (so the user gets a notification) or not. 
     Reply with 'yes' if the user should be notified or 'no' otherwise. 
     Reply with these replies exactly.
+  message_prompt: >
+    {% if trigger.payload_json['after']['sub_label'] %}
+      {{input_message}} The name of the person is {{ trigger.payload_json['after']['sub_label'][0] }}. Use that name in your summary.
+    {% else %}
+      {{input_message}}
+    {% endif %}
 
 trigger:
   - platform: mqtt
@@ -359,7 +366,7 @@ action:
               duration: !input duration
               provider: !input provider
               model: !input model
-              message: !input message
+              message: "{{message_prompt}}"
               remember: !input remember
               include_filename: true
               max_frames: !input max_frames

--- a/blueprints/event_summary.yaml
+++ b/blueprints/event_summary.yaml
@@ -57,14 +57,6 @@ blueprint:
             - bird
           multiple: true
           custom_value: true
-    update_sub_label:
-      name: Update Sub Label (Advanced)
-      description: |
-        Update the title and/or message with the matched face name and trigger a notification update. 
-        Requires face detection in Frigate to be configured.
-      default: false
-      selector:
-        boolean:
     preview_mode:
       name: Preview Mode
       description: (Camera mode only) Choose between a live preview or a snapshot of the event
@@ -185,7 +177,6 @@ variables:
   motion_sensors_list: !input motion_sensors
   input_labels: !input labels
   frigate_labels: "{{ input_labels | list | lower }}"
-  update_sub_label: !input update_sub_label
   camera_entity: >
     {% if mode == 'Camera' %}
       {% if motion_sensors_list %}
@@ -211,13 +202,7 @@ variables:
     {% endif %}
   label: >
     {% if mode == 'Frigate' %}
-      {% if event['after']['sub_label'] and update_sub_label %} 
-        {{event['after']['sub_label'][0]|capitalize}} seen
-      {% elif trigger.payload_json['after']['label'] %}      
-        {{ trigger.payload_json['after']['label']|capitalize}} seen
-      {% else %}
-        Motion detected
-      {% endif %}
+      {{ trigger.payload_json['after']['label']|capitalize }} seen
     {% else %}
       Motion detected
     {% endif %}

--- a/blueprints/event_summary.yaml
+++ b/blueprints/event_summary.yaml
@@ -279,6 +279,11 @@ action:
                   - condition: template
                     value_template: "{{ mode == 'Frigate'}}"
                 sequence:
+                  - delay:
+                    hours: 0
+                    minutes: 0
+                    seconds: 5
+                    milliseconds: 0
                   - service: llmvision.image_analyzer
                     data:
                       image_entity: "{{ ['camera.' + trigger.payload_json['after']['camera']|lower] }}"
@@ -342,12 +347,17 @@ action:
           - condition: template
             value_template: "{{ mode == 'Frigate' }}"
         sequence:
+          - delay:
+            hours: 0
+            minutes: 0
+            seconds: 5
+            milliseconds: 0
           - service: llmvision.video_analyzer
             data:
               event_id: "{{ trigger.payload_json['after']['id'] }}"
               provider: !input provider
               model: !input model
-              message: !input message
+              message: "{{message_prompt}}"
               remember: !input remember
               include_filename: true
               max_frames: !input max_frames

--- a/blueprints/event_summary.yaml
+++ b/blueprints/event_summary.yaml
@@ -57,6 +57,14 @@ blueprint:
             - bird
           multiple: true
           custom_value: true
+    update_sub_label:
+      name: Update Sub Label (Advanced)
+      description: |
+        Update the title and/or message with the matched face name and trigger a notification update. 
+        Requires face detection to be configured (Advanced). Requires Title and/or Message to contain 'A Person' or 'A {{ label }}'
+      default: true
+      selector:
+        boolean:
     preview_mode:
       name: Preview Mode
       description: (Camera mode only) Choose between a live preview or a snapshot of the event
@@ -177,6 +185,7 @@ variables:
   motion_sensors_list: !input motion_sensors
   input_labels: !input labels
   frigate_labels: "{{ input_labels | list | lower }}"
+  update_sub_label: !input update_sub_label
   camera_entity: >
     {% if mode == 'Camera' %}
       {% if motion_sensors_list %}
@@ -202,7 +211,13 @@ variables:
     {% endif %}
   label: >
     {% if mode == 'Frigate' %}
-      {{ trigger.payload_json['after']['label']|capitalize }} seen
+      {% if event['after']['sub_label'] and update_sub_label %} 
+        {{event['after']['sub_label'][0]|capitalize}} seen
+      {% elif trigger.payload_json['after']['label'] %}      
+        {{ trigger.payload_json['after']['label'][0]|capitalize}} seen
+      {% else %}
+        Motion detected
+      {% endif %}
     {% else %}
       Motion detected
     {% endif %}


### PR DESCRIPTION
I added configurable Frigate Labels, allowing to configure for which labels notifications shall be sent.
This reduces AI costs and unwanted messages.

Furthermore, if Sub_Labels are available, these are used for the Message title.