### PR TITLE
Fix duplicate frames and respect original frame rate

### DIFF
--- a/custom_components/llmvision/media_handlers.py
+++ b/custom_components/llmvision/media_handlers.py
@@ -347,8 +347,9 @@ class MediaProcessor:
                         ffmpeg_cmd = [
                             "ffmpeg",
                             "-i", video_path,
-                            "-vf", f"fps=1/{interval},select='eq(n\\,0)+not(mod(n\\,{interval}))'", os.path.join(
-                                tmp_frames_dir, "frame%04d.jpg")
+                            "-vf", f"fps=fps='source_fps',select='eq(n\\,0)+not(mod(n\\,{interval}))'", 
+                            "-fps_mode", "passthrough",
+                            os.path.join(tmp_frames_dir, "frame%04d.jpg")
                         ]
                         # Run ffmpeg command
                         await self.hass.loop.run_in_executor(None, os.system, " ".join(ffmpeg_cmd))


### PR DESCRIPTION
A couple of nuances of how ffmpeg works are fixed here:
1) The default ffmpeg frame rate is 25 fps, but many security cameras are set at 5-15 fps.  The new fps command (source_fps) sets the sampling rate to the original video's rate.
2) when decoding videos to images, ffmpeg will duplicate frames to match the output files to the input file.  This resulted in many duplicate frames.  We can set fps_mode to passthrough to tell ffmpeg that we don't want it to create duplicate frames to fill in the gaps.  That's why we used select!  We want to dump some frames!

Side note:  For debugging ffmpeg, it's useful to add another parameter to the command:  "2> /config/www/llmvision/out.txt" so we can see what it's doing.

This fixes https://github.com/valentinfrlch/ha-llmvision/issues/118 and also results in nice, smooth frames and drastically improves the descriptions the LLM returns.