### PR TITLE
event_summary blueprint: adjust the device name sanitization

### DIFF
--- a/blueprints/event_summary.yaml
+++ b/blueprints/event_summary.yaml
@@ -170,7 +170,7 @@ variables:
     {% set ns = namespace(device_names=[]) %}
     {% for device_id in notify_devices %}
       {% set device_name = device_attr(device_id, "name") %}
-      {% set sanitized_name = "mobile_app_" + device_name | lower | regex_replace("[^a-z0-9_\- ]", "") | replace(" ", "_") | replace("-", "_") %}
+      {% set sanitized_name = "mobile_app_" + device_name | lower | regex_replace("[' -]", "_") | regex_replace("[^a-z0-9_]", "")  %}
       {% set ns.device_names = ns.device_names + [sanitized_name] %}
     {% endfor %}
     {{ ns.device_names }}


### PR DESCRIPTION
The device name sanitize code was changed from "remove all non-conforming characters and then convert some special ones to `_`" to "convert some special characters to `_` and then remove all other non-conforming characters".

In the new version, both of these operations were changed to use regex replace only.  Note that in the "special characters" expression `[' -]` the '-' does not need to be escaped because it is the last item in the regex character class.  The "non-conforming characters" regex was changed to `[^a-z0-9_]`, which reflects that the special characters no longer need to be included.

An important addition to the "special characters" is the single-quote, which was previously omitted.