### PR TITLE
Blueprint upgrades

### DIFF
--- a/blueprints/event_summary.yaml
+++ b/blueprints/event_summary.yaml
@@ -49,6 +49,17 @@ blueprint:
           multiple: true
           filter:
             domain: camera
+    object_type:
+      name: Included Object Type(s)
+      description: >-
+        (Frigate mode only)
+
+        Only run if frigate labels the object as one of these. (person, dog, bird, etc)
+      default: []
+      selector:
+        text:
+          multiline: false
+          multiple: true
     trigger_state:
       name: Trigger State
       description: (Camera mode only) Trigger the automation when your cameras change to this state.
@@ -175,6 +186,7 @@ variables:
     {% endfor %}
     {{ ns.device_names }}
   camera_entities_list: !input camera_entities
+  object_types_list: !input object_type
   motion_sensors_list: !input motion_sensors
   camera_entity: >
     {% if mode == 'Camera' %}
@@ -251,7 +263,10 @@ condition:
   - condition: template
     value_template: >
       {% if mode == 'Frigate' %}
-        {{ trigger.payload_json["type"] == "end" and ('camera.' + trigger.payload_json['after']['camera']|lower) in camera_entities_list }}
+        {{ trigger.payload_json["type"] == "end"
+           and ('camera.' + trigger.payload_json['after']['camera']|lower) in camera_entities_list
+           and ((object_types_list|length) == 0 or ((trigger.payload_json['after']['label']|lower) in object_types_list))
+        }}
       {% endif %}
 
 

--- a/blueprints/event_summary.yaml
+++ b/blueprints/event_summary.yaml
@@ -230,6 +230,10 @@ variables:
     Use "critical" only for possible burglaries and similar events. "time-sensitive" could be a courier at the front door or an event of similar importance.
     Reply with these replies exactly.
 
+max_exceeded: silent
+
+mode: single
+
 trigger:
   - platform: mqtt
     topic: "frigate/events"
@@ -247,9 +251,7 @@ condition:
   - condition: template
     value_template: >
       {% if mode == 'Frigate' %}
-        {{ trigger.payload_json["type"] == "end" and (state_attr(this.entity_id, 'last_triggered') is none or (now() - state_attr(this.entity_id, 'last_triggered')).total_seconds() / 60 > cooldown) and ('camera.' + trigger.payload_json['after']['camera']|lower) in camera_entities_list }}
-      {% else %}
-        {{ state_attr(this.entity_id, 'last_triggered') is none or (now() - state_attr(this.entity_id, 'last_triggered')).total_seconds() / 60 > cooldown }}
+        {{ trigger.payload_json["type"] == "end" and ('camera.' + trigger.payload_json['after']['camera']|lower) in camera_entities_list }}
       {% endif %}
 
 
@@ -389,3 +391,5 @@ action:
                         tag: "{{tag}}"
                         group: "{{group}}"
                         interruption-level: passive
+
+- delay: 00:{{cooldown|int}}:00


### PR DESCRIPTION
_This is a repeat of the commit comments, which I think are pretty descriptive_

### Change 1: re-implement cooldown with singlemode execution and a delay
Force the automation to use single mode with suppressed warnings (see [here](https://www.home-assistant.io/docs/automation/modes/)).  To implement the cooldown, add a delay as the last action in the actions.  Also remove the cooldown from the automation conditions.

The main difference here is that no new triggers will arrive while the automation is running.  The condition is smaller now, and is limited to the content of the automation, and not managing how the automation is run.  With this narrowing, it opens up the possibility of adding other conditions to the blueprint config in the future.

### Change 2: blueprint: add a filter for frigate object detection
The frigate payload includes a label which indicates what the detected object is.  This can be useful to separate llm-vision automations to react differently for different objects.

For example, if a bird is detected, the ai instructions could include something like, "if you see a bird, try to identify what species it is".  This discription doesn't make much sense if the detected object is a person, and including separate instructions to the ai makes it more confusing on both the human and ai side of things.  Allowing for separate instructions by object will make for easier to understand automations. 