### PR TITLE
Fix custom openai integration

### DIFF
--- a/custom_components/llmvision/__init__.py
+++ b/custom_components/llmvision/__init__.py
@@ -17,6 +17,7 @@ from .const import (
     CONF_OLLAMA_HTTPS,
     CONF_CUSTOM_OPENAI_ENDPOINT,
     CONF_CUSTOM_OPENAI_API_KEY,
+    CONF_CUSTOM_OPENAI_DEFAULT_MODEL,
     CONF_RETENTION_TIME,
     MESSAGE,
     REMEMBER,
@@ -78,6 +79,7 @@ async def async_setup_entry(hass, entry):
     ollama_https = entry.data.get(CONF_OLLAMA_HTTPS)
     custom_openai_endpoint = entry.data.get(CONF_CUSTOM_OPENAI_ENDPOINT)
     custom_openai_api_key = entry.data.get(CONF_CUSTOM_OPENAI_API_KEY)
+    custom_openai_default_model = entry.data.get(CONF_CUSTOM_OPENAI_DEFAULT_MODEL)
     retention_time = entry.data.get(CONF_RETENTION_TIME)
 
     # Ensure DOMAIN exists in hass.data
@@ -102,6 +104,7 @@ async def async_setup_entry(hass, entry):
         CONF_OLLAMA_HTTPS: ollama_https,
         CONF_CUSTOM_OPENAI_ENDPOINT: custom_openai_endpoint,
         CONF_CUSTOM_OPENAI_API_KEY: custom_openai_api_key,
+        CONF_CUSTOM_OPENAI_DEFAULT_MODEL: custom_openai_default_model,
         CONF_RETENTION_TIME: retention_time
     }
 

--- a/custom_components/llmvision/config_flow.py
+++ b/custom_components/llmvision/config_flow.py
@@ -29,6 +29,7 @@ from .const import (
     CONF_OLLAMA_HTTPS,
     CONF_CUSTOM_OPENAI_API_KEY,
     CONF_CUSTOM_OPENAI_ENDPOINT,
+    CONF_CUSTOM_OPENAI_DEFAULT_MODEL,
     CONF_RETENTION_TIME,
 )
 import voluptuous as vol
@@ -296,17 +297,20 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_custom_openai(self, user_input=None):
         data_schema = vol.Schema({
-            vol.Required(CONF_CUSTOM_OPENAI_ENDPOINT): str,
-            vol.Optional(CONF_CUSTOM_OPENAI_API_KEY): str,
+            vol.Required(CONF_CUSTOM_OPENAI_ENDPOINT, default="http://replace.with.your.host.com/v1/chat/completions"): str,
+            vol.Required(CONF_CUSTOM_OPENAI_DEFAULT_MODEL, default="gpt-4o-mini"): str,
+            vol.Required(CONF_CUSTOM_OPENAI_API_KEY): str,
         })
 
         if user_input is not None:
             # save provider to user_input
             user_input["provider"] = self.init_info["provider"]
             try:
-                custom_openai = OpenAI(self.hass, api_key=user_input[CONF_CUSTOM_OPENAI_API_KEY], endpoint={
-                    'base_url': user_input[CONF_CUSTOM_OPENAI_ENDPOINT]
-                })
+                custom_openai = OpenAI(self.hass,
+                    api_key=user_input[CONF_CUSTOM_OPENAI_API_KEY],
+                    endpoint={'base_url': user_input[CONF_CUSTOM_OPENAI_ENDPOINT]},
+                    default_model=user_input[CONF_CUSTOM_OPENAI_DEFAULT_MODEL],
+                )
                 await custom_openai.validate()
                 # add the mode to user_input
                 user_input["provider"] = self.init_info["provider"]

--- a/custom_components/llmvision/const.py
+++ b/custom_components/llmvision/const.py
@@ -20,6 +20,7 @@ CONF_OLLAMA_PORT = 'ollama_port'
 CONF_OLLAMA_HTTPS = 'ollama_https'
 CONF_CUSTOM_OPENAI_ENDPOINT = 'custom_openai_endpoint'
 CONF_CUSTOM_OPENAI_API_KEY = 'custom_openai_api_key'
+CONF_CUSTOM_OPENAI_DEFAULT_MODEL = 'custom_openai_default_model'
 CONF_RETENTION_TIME = 'retention_time'
 
 # service call constants

--- a/custom_components/llmvision/strings.json
+++ b/custom_components/llmvision/strings.json
@@ -63,10 +63,11 @@
             },
             "custom_openai": {
                 "title": "Configure Custom OpenAI provider",
-                "description": "**Important**: Only works if the API is compatible with OpenAI's API. If the API doesn't require an API key, leave it empty. The endpoint must have the following format: `http(s)://baseURL(:port)/some/endpoint`",
+                "description": "**Important**: Only works if the API is compatible with OpenAI's API. If the API doesn't require an API key, enter a dummy value. The endpoint must have the following format: `http(s)://baseURL(:port)/some/endpoint`",
                 "data": {
                     "custom_openai_endpoint": "Custom Endpoint",
-                    "custom_openai_api_key": "Your API key"
+                    "custom_openai_api_key": "Your API key",
+                    "custom_openai_default_model": "Default model to use, e.g. gpt-4o-mini"
                 }
             },
             "semantic_index": {

--- a/custom_components/llmvision/translations/en.json
+++ b/custom_components/llmvision/translations/en.json
@@ -63,10 +63,11 @@
             },
             "custom_openai": {
                 "title": "Configure Custom OpenAI provider",
-                "description": "**Important**: Only works if the API is compatible with OpenAI's API. If the API doesn't require an API key, leave it empty. The endpoint must have the following format: `http(s)://baseURL(:port)/some/endpoint`",
+                "description": "**Important**: Only works if the API is compatible with OpenAI's API. If the API doesn't require an API key, enter a dummy value. The endpoint must have the following format: `http(s)://baseURL(:port)/some/endpoint`",
                 "data": {
                     "custom_openai_endpoint": "Custom Endpoint",
-                    "custom_openai_api_key": "Your API key"
+                    "custom_openai_api_key": "Your API key",
+                    "custom_openai_default_model": "Default model to use, e.g. gpt-4o-mini"
                 }
             },
             "semantic_index": {


### PR DESCRIPTION
The custom openai integration was not fully functional. This MR corrects it and allows for some more flexibility.
- Specify the full endpoint URL
- Set custom default model
- api_key is required by openai class, so make it mandatory