### PR TITLE
blueprint: add more notification control

### DIFF
--- a/blueprints/event_summary_beta.yaml
+++ b/blueprints/event_summary_beta.yaml
@@ -31,6 +31,14 @@ blueprint:
       default: false
       selector:
         boolean:
+    immediately_notify:
+      name: Immediately Notify
+      description: Send a notification immediately when motion is detected, before the
+        AI description is generated.  Once the AI description is generated, it should
+        replace the initial notification with the AI description.
+      default: true
+      selector:
+        boolean:
     notify_device:
       name: Notify Device
       description: The devices to send the notification to. Multiple devices may be used. Only works with Home Assistant mobile app.
@@ -40,6 +48,14 @@ blueprint:
           multiple: true
           filter:
             integration: mobile_app
+    notify_filter:
+      name: Notify Filter
+      description: Only notify when the AI generated description contains this text
+      default: ''
+      selector:
+        text:
+          multiline: false
+          multiple: false
     camera_entities:
       name: Camera Entities
       description: >-
@@ -199,6 +215,8 @@ variables:
   mode: !input mode
   preview_mode: !input preview_mode
   notify_devices: !input notify_device
+  initial_notify: !input immediately_notify
+  notify_filter_text: !input notify_filter
   device_name_map: >
     {% set ns = namespace(device_names=[]) %}
     {% for device_id in notify_devices %}
@@ -346,7 +364,7 @@ action:
   - choose:
       - conditions:
           - condition: template
-            value_template: "{{ image != '' or video != '' }}"
+            value_template: "{{ initial_notify and (image != '' or video != '') }}"
         sequence:
           - alias: "Send instant notification to notify devices"
             repeat:
@@ -413,7 +431,7 @@ action:
   - choose:
         - conditions:
             - condition: template
-              value_template: "{{ image != '' or video != '' }}"
+              value_template: "{{ ((notify_filter_text | length == 0) or notify_filter_text in response.response_text) and (image != '' or video != '') }}"
           sequence:
             - alias: "Send instant notification to notify devices"
               repeat:


### PR DESCRIPTION
When the automation is triggered, a notification is sent immediately to the user, and then the data is forwarded on to the llm engine.  Once the llm responds, the previous notification is updated with the description from the llm.

However, each of these will trigger a push notification on the user's device, which may ring the notificaiton tone or vibrate.  This may be undesirable for all users, so a new control is added to the automation blueprint to suppress the immediate notification.

Additionally, some responses from the llm may not be interesting to the user, and so a new 'filter' option is added to the automation blueprint which will suppress the second notification.

I am not sure if these changes are in contrast with what the `important` feature is trying to do.  

##### Testing
I noticed that the llm descriptions often (but not always) included "ninja" in the description, so I setup the automation to only notify if there was a ninja outside. 😆

I then removed the description trigger and received notifications for everything.

##### Note
Ultimately, I was thinking of forking this off into a separate blueprint that can set helper variables.  For example, if the AI detects a license plate and can recognize the characters in that license plate, it would be nice to have that captured into a helper.  Then someone could separately setup an automation that triggers on the helper value being changed.  This is a thought of a future feature that would need more design and testing.