### PR TITLE
Add quotes on video_path variable to allow spaces in it !202

### DIFF
--- a/custom_components/llmvision/media_handlers.py
+++ b/custom_components/llmvision/media_handlers.py
@@ -405,7 +405,7 @@ class MediaProcessor:
                     # Extract frames from video every interval seconds
                     ffmpeg_cmd = [
                         "ffmpeg",
-                        "-i", video_path,
+                        "-i", f"'{video_path}'",
                         "-vf", f"fps=fps='source_fps',select='eq(n\\,0)+not(mod(n\\,{interval}))'",
                         "-fps_mode", "passthrough",
                         os.path.join(tmp_frames_dir, "frame%d.jpg")


### PR DESCRIPTION
Hello! 

This MR fixes the `ffmpeg` command and puts the `video_path` variable between quotes. This fixes an issue with this integration that produced a failure when working with a failname with spaces.

More info on the issue !202.

Thanks,