### PR TITLE
Add prompt for title

### DIFF
--- a/blueprints/event_summary.yaml
+++ b/blueprints/event_summary.yaml
@@ -410,6 +410,7 @@ action:
               message: !input message
               remember: !input remember
               generate_title: !input remember
+              generate_title_prompt: !input remember
               include_filename: true
               max_frames: !input max_frames
               target_width: !input target_width
@@ -430,6 +431,7 @@ action:
               message: !input message
               remember: !input remember
               generate_title: !input remember
+              generate_title_prompt: !input remember
               include_filename: true
               max_frames: !input max_frames
               target_width: !input target_width

--- a/blueprints/event_summary_beta.yaml
+++ b/blueprints/event_summary_beta.yaml
@@ -279,6 +279,7 @@ action:
       expose_images: "{{preview_mode == 'Snapshot' or remember}}"
       expose_images_persist: !input remember
       generate_title: !input remember
+      generate_title_prompt: !input remember
       include_filename: true
       max_frames: !input max_frames
       target_width: !input target_width

--- a/custom_components/llmvision/__init__.py
+++ b/custom_components/llmvision/__init__.py
@@ -48,6 +48,7 @@ from .const import (
     EXPOSE_IMAGES,
     EXPOSE_IMAGES_PERSIST,
     GENERATE_TITLE,
+    GENERATE_TITLE_PROMPT,
     SENSOR_ENTITY,
 )
 from .calendar import SemanticIndex
@@ -313,6 +314,7 @@ class ServiceCallData:
         self.expose_images_persist = data_call.data.get(
             EXPOSE_IMAGES_PERSIST, False)
         self.generate_title = data_call.data.get(GENERATE_TITLE, False)
+        self.generate_title_prompt = data_call.data.get(GENERATE_TITLE_PROMPT, "Your job is to generate a title in the form '<object> seen' for texts. Do not mention the time, do not speculate. Generate a title for this text: {response}")
         self.sensor_entity = data_call.data.get(SENSOR_ENTITY)
         # ------------ Added during call ------------
         # self.base64_images : List[str] = []

--- a/custom_components/llmvision/const.py
+++ b/custom_components/llmvision/const.py
@@ -53,6 +53,7 @@ INCLUDE_FILENAME = 'include_filename'
 EXPOSE_IMAGES = 'expose_images'
 EXPOSE_IMAGES_PERSIST = 'expose_images_persist'
 GENERATE_TITLE = 'generate_title'
+GENERATE_TITLE_PROMPT = 'generate_title_prompt'
 SENSOR_ENTITY = 'sensor_entity'
 
 # Error messages

--- a/custom_components/llmvision/providers.py
+++ b/custom_components/llmvision/providers.py
@@ -144,8 +144,6 @@ class Request:
 
         self.validate(call)
 
-        gen_title_prompt = "Your job is to generate a title in the form '<object> seen' for texts. Do not mention the time, do not speculate. Generate a title for this text: {response}"
-
         if provider == 'OpenAI':
             api_key = config.get(CONF_OPENAI_API_KEY)
             provider_instance = OpenAI(hass=self.hass, api_key=api_key)
@@ -248,7 +246,7 @@ class Request:
         response_text = await provider_instance.vision_request(call)
 
         if call.generate_title:
-            call.message = gen_title_prompt.format(response=response_text)
+            call.message = call.generate_title_prompt.format(response=response_text)
             gen_title = await provider_instance.title_request(call)
 
             return {"title": re.sub(r'[^a-zA-Z0-9\s]', '', gen_title), "response_text": response_text}

--- a/custom_components/llmvision/providers.py
+++ b/custom_components/llmvision/providers.py
@@ -249,7 +249,7 @@ class Request:
             call.message = call.generate_title_prompt.format(response=response_text)
             gen_title = await provider_instance.title_request(call)
 
-            return {"title": re.sub(r'[^a-zA-Z0-9\s]', '', gen_title), "response_text": response_text}
+            return {"title": re.sub(r'[^a-zA-Z0-9ŽžÀ-ÿ\s]', '', gen_title), "response_text": response_text}
         else:
             return {"response_text": response_text}
 

--- a/custom_components/llmvision/services.yaml
+++ b/custom_components/llmvision/services.yaml
@@ -100,8 +100,8 @@ image_analyzer:
       name: Generate Title Prompt
       required: false
       description: Prompt for the title. (Used for notifications and remembered events)
-      example: "Your job is to generate a title in the form '<object> seen' for texts. Do not mention the time, do not speculate. Generate a title for this text: {response}"
-      default: false
+      default: "Your job is to generate a title in the form '<object> seen' for texts. Do not mention the time, do not speculate. Generate a title for this text: {response}"
+      selector:
         text:
           multiline: true
     expose_images:
@@ -254,6 +254,14 @@ video_analyzer:
       default: false
       selector:
         boolean:
+    generate_title_prompt:
+      name: Generate Title Prompt
+      required: false
+      description: Prompt for the title. (Used for notifications and remembered events)
+      default: "Your job is to generate a title in the form '<object> seen' for texts. Do not mention the time, do not speculate. Generate a title for this text: {response}"
+      selector:
+        text:
+          multiline: true
     expose_images:
       name: Expose Images
       description: (Experimental) Expose analyzed frames after processing. This will save analyzed frames in /www/llmvision so they can be used for notifications. (Only works for entity input, include camera name should be enabled). Existing files will be overwritten.
@@ -383,6 +391,14 @@ stream_analyzer:
       default: false
       selector:
         boolean:
+    generate_title_prompt:
+      name: Generate Title Prompt
+      required: false
+      description: Prompt for the title. (Used for notifications and remembered events)
+      default: "Your job is to generate a title in the form '<object> seen' for texts. Do not mention the time, do not speculate. Generate a title for this text: {response}"
+      selector:
+        text:
+          multiline: true
     expose_images:
       name: Expose Images
       description: (Experimental) Expose analyzed frames after processing. This will save analyzed frames in /www/llmvision so they can be used for notifications. (Only works for entity input, include camera name should be enabled). Existing files will be overwritten.

--- a/custom_components/llmvision/services.yaml
+++ b/custom_components/llmvision/services.yaml
@@ -96,6 +96,14 @@ image_analyzer:
       default: false
       selector:
         boolean:
+    generate_title_prompt:
+      name: Generate Title Prompt
+      required: false
+      description: Prompt for the title. (Used for notifications and remembered events)
+      example: "Your job is to generate a title in the form '<object> seen' for texts. Do not mention the time, do not speculate. Generate a title for this text: {response}"
+      default: false
+        text:
+          multiline: true
     expose_images:
       name: Expose Images
       description: (Experimental) Expose analyzed frames after processing. This will save analyzed frames in /www/llmvision so they can be used for notifications. (Only works for entity input, include camera name should be enabled). Existing files will be overwritten.


### PR DESCRIPTION
This PR adds a prompt option for the title as well. The reason for it, was because it was hardcoded and would return the title in English. With this PR you can modify the prompt, and potentially change language as well.