### PR TITLE
Fix Memory ARGB error and blueprint default model

### DIFF
--- a/blueprints/event_summary.yaml
+++ b/blueprints/event_summary.yaml
@@ -134,8 +134,8 @@ blueprint:
           integration: llmvision
     model:
       name: Model
-      description: Which model to use. Depends on chosen provider, leave balnk for default. e.g. 'gpt-4o-mini'
-      default: ""
+      description: Which model to use. Depends on chosen provider.
+      default: "gpt-4o-mini"
       selector:
         text:
           multiline: false
@@ -255,7 +255,7 @@ action:
               - action: "notify.{{ repeat.item }}"
                 data:
                   title: "{{ label }}"
-                  message: "Detection at Camera: {{camera}}"
+                  message: "{{camera}} Has Detected Activities."
                   data:
                     entity_id: "{{camera_entity}}"
                     url: !input tap_navigate #iOS

--- a/blueprints/event_summary.yaml
+++ b/blueprints/event_summary.yaml
@@ -134,8 +134,8 @@ blueprint:
           integration: llmvision
     model:
       name: Model
-      description: Which model to use. Depends on chosen provider.
-      default: "gpt-4o-mini"
+      description: Which model to use. Depends on chosen provider, leave balnk for default. e.g. 'gpt-4o-mini'
+      default: ""
       selector:
         text:
           multiline: false
@@ -255,7 +255,7 @@ action:
               - action: "notify.{{ repeat.item }}"
                 data:
                   title: "{{ label }}"
-                  message: "{{camera}}"
+                  message: "Detection at Camera: {{camera}}"
                   data:
                     entity_id: "{{camera_entity}}"
                     url: !input tap_navigate #iOS

--- a/custom_components/llmvision/memory.py
+++ b/custom_components/llmvision/memory.py
@@ -151,6 +151,10 @@ class Memory:
                     new_width = int(512 * aspect_ratio)
                 img = img.resize((new_width, new_height))
 
+                # Convert Memory Images to RGB mode if needed
+                if img.mode == "RGBA":
+                    img = img.convert("RGB")
+
                 # Encode the image to base64
                 img_byte_arr = io.BytesIO()
                 img.save(img_byte_arr, format='JPEG')


### PR DESCRIPTION
1. Fixed #241 issue, when user uploads images that may be "ARGB", causing the memory module broken.
3. Refined blueprints, remove gpt 4 as default so it would be more friendly for gemini and other models.
4. updated notification titles for clarity.

