### PR TITLE
Sanitizing 'http://' or 'https://' from IP address input field for ollama and openwebui

### DIFF
--- a/custom_components/llmvision/config_flow.py
+++ b/custom_components/llmvision/config_flow.py
@@ -291,7 +291,7 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                                 api_key="",
                                 model=user_input[CONF_DEFAULT_MODEL],
                                 endpoint={
-                                    'ip_address': user_input[CONF_IP_ADDRESS],
+                                    'ip_address': re.sub(r'^https?://', '', user_input[CONF_IP_ADDRESS]),
                                     'port': user_input[CONF_PORT],
                                     'https': user_input[CONF_HTTPS],
                                     'keep_alive': user_input[CONF_KEEP_ALIVE],
@@ -388,7 +388,7 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             user_input = flatten_dict(user_input)
             try:
                 endpoint = ENDPOINT_OPENWEBUI.format(
-                    ip_address=user_input[CONF_IP_ADDRESS],
+                    ip_address=re.sub(r'^https?://', '', user_input[CONF_IP_ADDRESS]),
                     port=user_input[CONF_PORT],
                     protocol="https" if user_input[CONF_HTTPS] else "http"
                 )

--- a/custom_components/llmvision/config_flow.py
+++ b/custom_components/llmvision/config_flow.py
@@ -1,5 +1,6 @@
 import voluptuous as vol
 import os
+import re
 import logging
 from homeassistant import config_entries
 from homeassistant.helpers.selector import selector


### PR DESCRIPTION
When inputting `IP address` field, would get the validator error below if included the http:// or https:// protocol prefix.
<img width="444" height="373" alt="image" src="https://github.com/user-attachments/assets/a6a95b03-b463-49d1-be2d-cca569b7e5eb" />


This change sanitizes the input to strip the  protocol if included by the user.
