### PR TITLE
GPT-5 OpenAI provider incompatibility

### DIFF
--- a/custom_components/llmvision/providers.py
+++ b/custom_components/llmvision/providers.py
@@ -505,7 +505,7 @@ class OpenAI(Provider):
                 "model": self.model,
                 "messages": [{"role": "user", "content": [{"type": "text", "text": "Hi"}]}],
                 "max_completion_tokens": 1,
-                "temperature": 0.5
+                "temperature": 1.0
             }
             await self._post(url=self.endpoint.get('base_url'), headers=headers, data=data)
         else:

--- a/custom_components/llmvision/providers.py
+++ b/custom_components/llmvision/providers.py
@@ -504,7 +504,7 @@ class OpenAI(Provider):
             data = {
                 "model": self.model,
                 "messages": [{"role": "user", "content": [{"type": "text", "text": "Hi"}]}],
-                "max_completion_tokens": 1,
+                "max_completion_tokens": 4,
                 "temperature": 1.0
             }
             await self._post(url=self.endpoint.get('base_url'), headers=headers, data=data)


### PR DESCRIPTION
This pull request modifies the default parameters used in the validation request for the OpenAI provider to future-proof for future models. Specifically it modifies the parameters in `OpenAI#validate()`.

When configuring the OpenAI provider to use the new gpt-5 models. I encountered an issue:

```
...
DEBUG (MainThread) [custom_components.llmvision] OpenAI provider v2.1
DEBUG (MainThread) [custom_components.llmvision] Config entry OpenAI data: {'provider': 'OpenAI', 'api_key': '[REDACTED]', 'default_model': 'gpt-5-mini', 'temperature': 1.0, 'top_p': 0.9}
DEBUG (MainThread) [custom_components.llmvision.providers] Provider initialized: Openai(model=gpt-5-mini, endpoint={'base_url': 'https://api.openai.com/v1/chat/completions'})
DEBUG (MainThread) [custom_components.llmvision.providers] Request data: {'model': 'gpt-5-mini', 'messages': [{'role': 'user', 'content': [{'type': 'text', 'text': 'Hi'}]}], 'max_completion_tokens': 1, 'temperature': 0.5}
DEBUG (MainThread) [custom_components.llmvision.providers] Posting to https://api.openai.com/v1/chat/completions
DEBUG (MainThread) [custom_components.llmvision.providers] [INFO] Full Response: {
  "error": {
    "message": "Unsupported value: 'temperature' does not support 0.5 with this model. Only the default (1) value is supported.",
    "type": "invalid_request_error",
    "param": "temperature",
    "code": "unsupported_value"
  }
}
ERROR (MainThread) [custom_components.llmvision.config_flow] Validation failed: Unsupported value: 'temperature' does not support 0.5 with this model. Only the default (1) value is supported.
...
```

> **Unsupported value: 'temperature' does not support 0.5 with this model. Only the default (1) value is supported.**

It seems like the new models do not support the temperature parameter. This is also supported by some forum posts online, such as [this one](https://community.openai.com/t/temperature-in-gpt-5-models/1337133).

I changed the default parameter for `temperature` to be 1.0 and tested it again. This time I received this error:
> **Could not finish the message because max_tokens or model output limit was reached. Please try again with higher max_tokens.**

It seems like the new models now respond with 4 tokens:
> Hey how's it going?

So I changed the `max_completion_tokens` to be 4 and it seems to work with the new gpt-5 models again.
