### PR TITLE
Media folder fix

### DIFF
--- a/custom_components/llmvision/calendar.py
+++ b/custom_components/llmvision/calendar.py
@@ -174,7 +174,7 @@ class Timeline(CalendarEntity):
             async with aiosqlite.connect(self._db_path) as db:
                 await db.execute(
                     """
-                    UPDATE events SET key_frame = REPLACE(key_frame, '/media/llmvision/snapshots', '/media/local/llmvision/snapshots')
+                    UPDATE events SET key_frame = REPLACE(key_frame, '/config/media/llmvision/snapshots', '/media/local/llmvision/snapshots')
                 """
                 )
                 await db.commit()

--- a/custom_components/llmvision/calendar.py
+++ b/custom_components/llmvision/calendar.py
@@ -45,7 +45,7 @@ class Timeline(CalendarEntity):
 
         # Path to the JSON file where events are stored
         self._db_path = os.path.join(self.hass.config.path(DOMAIN), "events.db")
-        self._file_path = self.hass.config.path(f"media/{DOMAIN}/snapshots")
+        self._file_path = f"/media/{DOMAIN}/snapshots"
         # Ensure the directory exists
         os.makedirs(os.path.dirname(self._db_path), exist_ok=True)
         os.makedirs(self._file_path, exist_ok=True)
@@ -111,7 +111,7 @@ class Timeline(CalendarEntity):
         except aiosqlite.Error as e:
             _LOGGER.error(f"Error migrating events.db: {e}")
 
-        # v3 -> v4: Migrate image paths to /media/llmvision/snapshots from /www/llmvision
+        # v3 -> v4: Migrate image paths to /config/media/llmvision/snapshots from /www/llmvision
         try:
             # Move images to new location
             # Ensure dir exists
@@ -140,6 +140,41 @@ class Timeline(CalendarEntity):
                 await db.execute(
                     """
                     UPDATE events SET key_frame = REPLACE(key_frame, '/www/llmvision', '/media/llmvision/snapshots')
+                """
+                )
+                await db.commit()
+        except aiosqlite.Error as e:
+            _LOGGER.error(f"Error migrating image paths in events.db: {e}")
+
+        # v4 -> v4.1: Migrate image paths to /media/llmvision/snapshots from /config/media/llmvision/snapshots
+        try:
+            # Move images to new location
+            # Ensure dir exists
+            await self.hass.loop.run_in_executor(
+                None,
+                partial(
+                    os.makedirs,
+                    "/media/llmvision/snapshots",
+                    exist_ok=True,
+                ),
+            )
+            src_dir = self.hass.config.path("media/llmvision/snapshots")
+            dst_dir = "/media/llmvision/snapshots"
+            if os.path.exists(src_dir):
+                for filename in await self.hass.loop.run_in_executor(
+                    None, partial(os.listdir, src_dir)
+                ):
+                    src_file = os.path.join(src_dir, filename)
+                    dst_file = os.path.join(dst_dir, filename)
+                    if os.path.isfile(src_file):
+                        await self.hass.loop.run_in_executor(
+                            None, shutil.move, src_file, dst_file
+                        )
+
+            async with aiosqlite.connect(self._db_path) as db:
+                await db.execute(
+                    """
+                    UPDATE events SET key_frame = REPLACE(key_frame, '/media/llmvision/snapshots', '/media/local/llmvision/snapshots')
                 """
                 )
                 await db.commit()

--- a/custom_components/llmvision/media_handlers.py
+++ b/custom_components/llmvision/media_handlers.py
@@ -34,7 +34,7 @@ class MediaProcessor:
         self.client = client
         self.base64_images = []
         self.filenames = []
-        self.path = self.hass.config.path(f"media/{DOMAIN}/snapshots/")
+        self.path = f"/media/{DOMAIN}/snapshots/"
         self.key_frame = ""
 
     async def _encode_image(self, img):
@@ -77,10 +77,10 @@ class MediaProcessor:
         # ensure /media/llmvision/snapshots dir exists
         await self.hass.loop.run_in_executor(
             None,
-            partial(os.makedirs, self.hass.config.path(f"media/{DOMAIN}/snapshots"), exist_ok=True),
+            partial(os.makedirs, f"/media/{DOMAIN}/snapshots", exist_ok=True),
         )
         if self.key_frame == "":
-            filename = self.hass.config.path(f"media/{DOMAIN}/snapshots/{uid}-{frame_name}.jpg")
+            filename = f"/media/{DOMAIN}/snapshots/{uid}-{frame_name}.jpg"
             self.key_frame = filename
             if image_data is None and frame_path is not None:
                 # open image in hass.loop


### PR DESCRIPTION
This pull request standardizes the file paths used for storing and accessing snapshot images in the `llmvision` component, moving away from Home Assistant's internal config path resolution to using absolute `/media/llmvision/snapshots` paths. It also introduces a migration step to move existing images and update database references accordingly.

**File path standardization:**

* Changed all references to the snapshots directory from using `self.hass.config.path("media/llmvision/snapshots")` to the absolute path `/media/llmvision/snapshots` in both `calendar.py` and `media_handlers.py`. [[1]](diffhunk://#diff-214dfdae5aebe50db83be095f3afde57439f8adf27e8776cbe34b14d93fae6a6L48-R48) [[2]](diffhunk://#diff-00ca4b9da6c78b83ae4cd6532bf85c1175ed586dd73bd7c4cb716fde2c44fcabL37-R37) [[3]](diffhunk://#diff-00ca4b9da6c78b83ae4cd6532bf85c1175ed586dd73bd7c4cb716fde2c44fcabL80-R83)

**Database and media migration:**

* Updated migration comments and logic to reflect the new paths, clarifying the migration steps from `/www/llmvision` to `/config/media/llmvision/snapshots`, and then from `/config/media/llmvision/snapshots` to `/media/llmvision/snapshots`. [[1]](diffhunk://#diff-214dfdae5aebe50db83be095f3afde57439f8adf27e8776cbe34b14d93fae6a6L114-R114) [[2]](diffhunk://#diff-214dfdae5aebe50db83be095f3afde57439f8adf27e8776cbe34b14d93fae6a6R149-R183)
* Added a new migration step (v4 → v4.1) that moves images from the old config-based media directory to the new absolute path and updates database entries to reference `/media/local/llmvision/snapshots`.