### PR TITLE
(Provider) Anthropic: Add sampling mode

### DIFF
--- a/custom_components/llmvision/__init__.py
+++ b/custom_components/llmvision/__init__.py
@@ -67,6 +67,7 @@ from .const import (
     DEFAULT_OPENWEBUI_MODEL,
     CONF_CONTEXT_WINDOW,
     CONF_KEEP_ALIVE,
+    CONF_SAMPLING_MODE
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -85,6 +86,7 @@ async def async_setup_entry(hass, entry):
         CONF_HTTPS: entry.data.get(CONF_HTTPS),
         CONF_DEFAULT_MODEL: entry.data.get(CONF_DEFAULT_MODEL),
         CONF_TEMPERATURE: entry.data.get(CONF_TEMPERATURE),
+        CONF_SAMPLING_MODE: entry.data.get(CONF_SAMPLING_MODE),
         CONF_TOP_P: entry.data.get(CONF_TOP_P),
         # Ollama specific
         CONF_CONTEXT_WINDOW: entry.data.get(CONF_CONTEXT_WINDOW),

--- a/custom_components/llmvision/const.py
+++ b/custom_components/llmvision/const.py
@@ -12,6 +12,7 @@ CONF_HTTPS = "https"
 CONF_DEFAULT_MODEL = "default_model"
 CONF_TEMPERATURE = "temperature"
 CONF_TOP_P = "top_p"
+CONF_SAMPLING_MODE = "sampling_mode"
 CONF_CONTEXT_WINDOW = "context_window"  # (ollama: num_ctx)
 CONF_KEEP_ALIVE = "keep_alive"
 
@@ -84,7 +85,7 @@ DATA_EXTRACTION_PROMPT = "Analyze the image(s) and extract only the requested in
 
 # Models
 DEFAULT_OPENAI_MODEL = "gpt-4o-mini"
-DEFAULT_ANTHROPIC_MODEL = "claude-3-7-sonnet-latest"
+DEFAULT_ANTHROPIC_MODEL = "claude-haiku-4-5-20251001"
 DEFAULT_AZURE_MODEL = "gpt-4o-mini"
 DEFAULT_GOOGLE_MODEL = "gemini-2.0-flash"
 DEFAULT_GROQ_MODEL = "meta-llama/llama-4-scout-17b-16e-instruct"

--- a/custom_components/llmvision/strings.json
+++ b/custom_components/llmvision/strings.json
@@ -160,11 +160,13 @@
                         "description": "Set default model parameters",
                         "data": {
                             "default_model": "Default model",
+                            "sampling_mode": "Sampling mode",
                             "temperature": "Temperature",
                             "top_p": "Top P"
                         },
                         "data_description": {
                             "default_model": "The default model to use when no other model is specified.",
+                            "sampling_mode": "Anthropic allows to only select one of 'temperature' or 'top_p' sampling modes at a time.",
                             "temperature": "Controls the randomness of the output. Lower values make the output more deterministic.",
                             "top_p": "Controls the diversity of the output. Lower values make the output more focused."
                         }

--- a/custom_components/llmvision/translations/en.json
+++ b/custom_components/llmvision/translations/en.json
@@ -160,11 +160,13 @@
                         "description": "Set default model parameters",
                         "data": {
                             "default_model": "Default model",
+                            "sampling_mode": "Sampling mode",
                             "temperature": "Temperature",
                             "top_p": "Top P"
                         },
                         "data_description": {
                             "default_model": "The default model to use when no other model is specified.",
+                            "sampling_mode": "Anthropic allows to only select one of 'temperature' or 'top_p' sampling modes at a time.",
                             "temperature": "Controls the randomness of the output. Lower values make the output more deterministic.",
                             "top_p": "Controls the diversity of the output. Lower values make the output more focused."
                         }


### PR DESCRIPTION
The Anthropic integration is currently broken, because the API allows only the use of either temperature or top p, but not both at the same time. This MR creates a new configuration item for anthropic to select the preferred sampling mode (defaults to temperature).
Claude Code suggested a few code layout changes that I left in there as well, because it makes the code a more readable.