### PR TITLE
Add MiniMax as first-class LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 </p>
 
 ## Features
-- Supports OpenRouter, OpenAI, Anthropic, Google Gemini, AWS Bedrock, Azure, Groq, [Ollama](https://ollama.com/), [Open WebUI](https://github.com/open-webui/open-webui), [LocalAI](https://github.com/mudler/LocalAI) and any provider with OpenAI compatible endpoints.
+- Supports OpenRouter, OpenAI, Anthropic, Google Gemini, AWS Bedrock, Azure, Groq, MiniMax, [Ollama](https://ollama.com/), [Open WebUI](https://github.com/open-webui/open-webui), [LocalAI](https://github.com/mudler/LocalAI) and any provider with OpenAI compatible endpoints.
 - Answers questions and provides descriptions of images, video files, live camera feeds, and Frigate events based on your prompt.
 - Remembers people, pets and objects
 - Keeps a timeline of camera events, so you can display them on your dashboard or ask Assist about them.

--- a/custom_components/llmvision/config_flow.py
+++ b/custom_components/llmvision/config_flow.py
@@ -54,9 +54,11 @@ from .const import (
     DEFAULT_AWS_MODEL,
     DEFAULT_OPENWEBUI_MODEL,
     DEFAULT_OPENROUTER_MODEL,
+    DEFAULT_MINIMAX_MODEL,
     ENDPOINT_OPENWEBUI,
     ENDPOINT_AZURE,
     ENDPOINT_OPENROUTER,
+    ENDPOINT_MINIMAX,
     CONF_CONTEXT_WINDOW,
     CONF_KEEP_ALIVE,
     VERSION_AZURE,
@@ -80,6 +82,7 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             "Google": self.async_step_google,
             "Groq": self.async_step_groq,
             "LocalAI": self.async_step_localai,
+            "MiniMax": self.async_step_minimax,
             "Ollama": self.async_step_ollama,
             "OpenAI": self.async_step_openai,
             "OpenWebUI": self.async_step_openwebui,
@@ -118,6 +121,7 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                                 "Google",
                                 "Groq",
                                 "LocalAI",
+                                "MiniMax",
                                 "Ollama",
                                 "OpenAI",
                                 "OpenWebUI",
@@ -1562,6 +1566,109 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="openrouter",
+            data_schema=data_schema,
+        )
+
+    async def async_step_minimax(self, user_input=None):
+        data_schema = vol.Schema(
+            {
+                vol.Optional("connection_section"): section(
+                    vol.Schema(
+                        {
+                            vol.Required(CONF_API_KEY): selector(
+                                {"text": {"type": "password"}}
+                            ),
+                        }
+                    ),
+                    {"collapsed": False},
+                ),
+                vol.Optional("model_section"): section(
+                    vol.Schema(
+                        {
+                            vol.Required(
+                                CONF_DEFAULT_MODEL, default=DEFAULT_MINIMAX_MODEL
+                            ): str,
+                            vol.Optional(CONF_TEMPERATURE, default=0.5): selector(
+                                {
+                                    "number": {
+                                        "min": 0,
+                                        "max": 1,
+                                        "step": 0.1,
+                                        "mode": "slider",
+                                    }
+                                }
+                            ),
+                            vol.Optional(CONF_TOP_P, default=0.9): selector(
+                                {
+                                    "number": {
+                                        "min": 0,
+                                        "max": 1,
+                                        "step": 0.1,
+                                        "mode": "slider",
+                                    }
+                                }
+                            ),
+                        }
+                    ),
+                    {"collapsed": False},
+                ),
+            }
+        )
+
+        if self.source == config_entries.SOURCE_RECONFIGURE:
+            # load existing configuration and add it to the dialog
+            self.init_info = self._get_reconfigure_entry().data
+            # Re-nest the flat config entry data into sections
+            suggested = {
+                "connection_section": {
+                    CONF_API_KEY: self.init_info.get(CONF_API_KEY),
+                },
+                "model_section": {
+                    CONF_DEFAULT_MODEL: self.init_info.get(
+                        CONF_DEFAULT_MODEL, DEFAULT_MINIMAX_MODEL
+                    ),
+                    CONF_TEMPERATURE: self.init_info.get(CONF_TEMPERATURE, 0.5),
+                    CONF_TOP_P: self.init_info.get(CONF_TOP_P, 0.9),
+                },
+            }
+            data_schema = self.add_suggested_values_to_schema(data_schema, suggested)
+
+        if user_input is not None:
+            # save provider to user_input
+            user_input[CONF_PROVIDER] = self.init_info[CONF_PROVIDER]
+            # flatten dict to remove nested keys
+            user_input = flatten_dict(user_input)
+            try:
+                minimax = OpenAI(
+                    self.hass,
+                    api_key=user_input[CONF_API_KEY],
+                    model=user_input[CONF_DEFAULT_MODEL],
+                    endpoint={
+                        "base_url": ENDPOINT_MINIMAX,
+                    },
+                )
+                await minimax.validate()
+                # add the mode to user_input
+                user_input[CONF_PROVIDER] = self.init_info[CONF_PROVIDER]
+                if self.source == config_entries.SOURCE_RECONFIGURE:
+                    # we're reconfiguring an existing config
+                    return self.async_update_reload_and_abort(
+                        self._get_reconfigure_entry(),
+                        data_updates=user_input,
+                    )
+                else:
+                    # New config entry
+                    return self.async_create_entry(title="MiniMax", data=user_input)
+            except ServiceValidationError as e:
+                _LOGGER.error(f"Validation failed: {e}")
+                return self.async_show_form(
+                    step_id="minimax",
+                    data_schema=data_schema,
+                    errors={"base": "handshake_failed"},
+                )
+
+        return self.async_show_form(
+            step_id="minimax",
             data_schema=data_schema,
         )
 

--- a/custom_components/llmvision/const.py
+++ b/custom_components/llmvision/const.py
@@ -101,6 +101,7 @@ DEFAULT_CUSTOM_OPENAI_MODEL = "gpt-4o-mini"
 DEFAULT_AWS_MODEL = "us.amazon.nova-pro-v1:0"
 DEFAULT_OPENWEBUI_MODEL = "gemma3:4b"
 DEFAULT_OPENROUTER_MODEL = "mistralai/mistral-small-3.2-24b-instruct:free"
+DEFAULT_MINIMAX_MODEL = "MiniMax-M1"
 
 DEFAULT_SUMMARY_PROMPT = "Provide a brief summary for the following titles. Focus on the key actions or changes that occurred over time and avoid unnecessary details or subjective interpretations. The summary should be concise, objective, and relevant to the content of the images. Keep the summary under 50 words and ensure it captures the main events or activities described in the descriptions. Here are the descriptions:\n "
 
@@ -114,3 +115,4 @@ ENDPOINT_OLLAMA = "{protocol}://{ip_address}:{port}/api/chat"
 ENDPOINT_OPENWEBUI = "{protocol}://{ip_address}:{port}/api/chat/completions"
 ENDPOINT_AZURE = "{base_url}openai/deployments/{deployment}/chat/completions?api-version={api_version}"
 ENDPOINT_OPENROUTER = "https://openrouter.ai/api/v1/chat/completions"
+ENDPOINT_MINIMAX = "https://api.minimax.io/v1/chat/completions"

--- a/custom_components/llmvision/providers.py
+++ b/custom_components/llmvision/providers.py
@@ -36,6 +36,7 @@ from .const import (
     ENDPOINT_OPENWEBUI,
     ENDPOINT_GROQ,
     ENDPOINT_OPENROUTER,
+    ENDPOINT_MINIMAX,
     ERROR_NOT_CONFIGURED,
     ERROR_GROQ_MULTIPLE_IMAGES,
     ERROR_NO_IMAGE_INPUT,
@@ -50,6 +51,7 @@ from .const import (
     DEFAULT_AWS_MODEL,
     DEFAULT_OPENWEBUI_MODEL,
     DEFAULT_OPENROUTER_MODEL,
+    DEFAULT_MINIMAX_MODEL,
     CONF_KEEP_ALIVE,
     CONF_CONTEXT_WINDOW,
     CONF_TEMPERATURE,
@@ -126,6 +128,7 @@ class Request:
             "AWS": DEFAULT_AWS_MODEL,  # For backwards compatibility
             "Open WebUI": DEFAULT_OPENWEBUI_MODEL,
             "OpenRouter": DEFAULT_OPENROUTER_MODEL,
+            "MiniMax": DEFAULT_MINIMAX_MODEL,
         }.get(provider_name)
 
     def validate(self, call: Any) -> None | ServiceValidationError:
@@ -1938,6 +1941,14 @@ class ProviderFactory:
                 api_key=cast(str, config.get(CONF_API_KEY) or ""),
                 model=model,
                 endpoint={"base_url": ENDPOINT_OPENROUTER},
+            )
+
+        if provider_name == "MiniMax":
+            return OpenAI(
+                hass,
+                api_key=cast(str, config.get(CONF_API_KEY) or ""),
+                model=model,
+                endpoint={"base_url": ENDPOINT_MINIMAX},
             )
 
         raise ServiceValidationError("invalid_provider")

--- a/custom_components/llmvision/translations/ca.json
+++ b/custom_components/llmvision/translations/ca.json
@@ -349,6 +349,36 @@
                     }
                 }
             },
+            "minimax": {
+                "title": "Configurar MiniMax",
+                "description": "Proporcioneu una clau API vàlida de MiniMax. Obteniu-ne una a [platform.minimaxi.com](https://platform.minimaxi.com/).",
+                "sections": {
+                    "connection_section": {
+                        "name": "Connexió",
+                        "description": "Autenticació de MiniMax",
+                        "data": {
+                            "api_key": "Clau API"
+                        },
+                        "data_description": {
+                            "api_key": "La vostra clau API de MiniMax."
+                        }
+                    },
+                    "model_section": {
+                        "name": "Model",
+                        "description": "Configureu els paràmetres predeterminats del model",
+                        "data": {
+                            "default_model": "Model predeterminat",
+                            "temperature": "Temperatura",
+                            "top_p": "Top P"
+                        },
+                        "data_description": {
+                            "default_model": "El model predeterminat que s'utilitzarà quan no s'especifiqui cap altre model. Recomanat: MiniMax-M1",
+                            "temperature": "Controla l'aleatorietat de la sortida. Valors més baixos fan que la sortida sigui més determinista.",
+                            "top_p": "Controla la diversitat de la sortida. Valors més baixos fan que la sortida sigui més enfocada."
+                        }
+                    }
+                }
+            },
             "settings": {
                 "title": "Configuració",
                 "description": "Configureu la integració de LLM Vision. Aquesta entrada és necessària abans de configurar altres proveïdors. Si voleu utilitzar la configuració predeterminada, simplement premeu 'Enviar'.",

--- a/custom_components/llmvision/translations/cn.json
+++ b/custom_components/llmvision/translations/cn.json
@@ -349,6 +349,36 @@
                     }
                 }
             },
+            "minimax": {
+                "title": "配置MiniMax",
+                "description": "请输入有效的MiniMax API密钥。在 [platform.minimaxi.com](https://platform.minimaxi.com/) 获取。",
+                "sections": {
+                    "connection_section": {
+                        "name": "连接",
+                        "description": "MiniMax认证",
+                        "data": {
+                            "api_key": "API密钥"
+                        },
+                        "data_description": {
+                            "api_key": "您的MiniMax API密钥。"
+                        }
+                    },
+                    "model_section": {
+                        "name": "模型",
+                        "description": "设置默认模型参数",
+                        "data": {
+                            "default_model": "默认模型",
+                            "temperature": "温度",
+                            "top_p": "Top P"
+                        },
+                        "data_description": {
+                            "default_model": "当未指定其他模型时使用的默认模型。推荐：MiniMax-M1",
+                            "temperature": "控制输出的随机性。较低的值使输出更确定。",
+                            "top_p": "控制输出的多样性。较低的值使输出更集中。"
+                        }
+                    }
+                }
+            },
             "settings": {
                 "title": "设置",
                 "description": "配置LLM视觉集成。在设置其他提供商之前，必须先完成此项。如果您想使用默认设置，只需点击“提交”。",

--- a/custom_components/llmvision/translations/cs.json
+++ b/custom_components/llmvision/translations/cs.json
@@ -349,6 +349,36 @@
                     }
                 }
             },
+            "minimax": {
+                "title": "Konfigurace MiniMax",
+                "description": "Zadejte platný API klíč pro MiniMax. Získejte ho na [platform.minimaxi.com](https://platform.minimaxi.com/).",
+                "sections": {
+                    "connection_section": {
+                        "name": "Připojení",
+                        "description": "MiniMax autentifikace",
+                        "data": {
+                            "api_key": "API klíč"
+                        },
+                        "data_description": {
+                            "api_key": "Váš MiniMax API klíč."
+                        }
+                    },
+                    "model_section": {
+                        "name": "Model",
+                        "description": "Nastavit základní parametry modelu",
+                        "data": {
+                            "default_model": "Předvolený model",
+                            "temperature": "Teplota",
+                            "top_p": "Top P"
+                        },
+                        "data_description": {
+                            "default_model": "Využití předvoleného modelu, pokud není specifikovaný jiný. Doporučeno: MiniMax-M1",
+                            "temperature": "Nastavení náhodnosti výstupu. Menší hodnoty vytvoří výstup více deterministický.",
+                            "top_p": "Kontroluje diverzitu výstupu. Nižší hodnoty vytvoří výstup více soustředěný."
+                        }
+                    }
+                }
+            },
             "settings": {
                 "title": "Nastavení",
                 "description": "Nastavení LLM Vision integrace. Tento vstup je vyžadován předtím než se nastaví další poskytovatel. Pokud si přejete použít předvolené nastavení, stačí stisknout 'Potvrdit'.",

--- a/custom_components/llmvision/translations/de.json
+++ b/custom_components/llmvision/translations/de.json
@@ -349,6 +349,36 @@
                     }
                 }
             },
+            "minimax": {
+                "title": "MiniMax konfigurieren",
+                "description": "Gib einen gültigen MiniMax API-Key ein. Erhalte einen auf [platform.minimaxi.com](https://platform.minimaxi.com/).",
+                "sections": {
+                    "connection_section": {
+                        "name": "Verbindung",
+                        "description": "MiniMax Authentifizierung",
+                        "data": {
+                            "api_key": "API-Key"
+                        },
+                        "data_description": {
+                            "api_key": "Dein MiniMax API-Key."
+                        }
+                    },
+                    "model_section": {
+                        "name": "Modell",
+                        "description": "Standardmodell-Parameter festlegen",
+                        "data": {
+                            "default_model": "Standardmodell",
+                            "temperature": "Temperatur",
+                            "top_p": "Top P"
+                        },
+                        "data_description": {
+                            "default_model": "Das Standardmodell, das verwendet wird, wenn kein anderes Modell angegeben ist. Empfohlen: MiniMax-M1",
+                            "temperature": "Bestimmt die Zufälligkeit der Ausgabe. Niedrigere Werte machen die Ausgabe deterministischer.",
+                            "top_p": "Bestimmt die Vielfalt der Ausgabe. Niedrigere Werte machen die Ausgabe fokussierter."
+                        }
+                    }
+                }
+            },
             "settings": {
                 "title": "Einstellungen",
                 "description": "Konfiguriere die LLM Vision-Integration. Dieser Eintrag ist erforderlich, bevor andere Anbieter eingerichtet werden können. Wenn Sie die Standardeinstellungen verwenden möchten, drücken Sie einfach 'Absenden'.",

--- a/custom_components/llmvision/translations/en.json
+++ b/custom_components/llmvision/translations/en.json
@@ -349,6 +349,36 @@
                     }
                 }
             },
+            "minimax": {
+                "title": "Configure MiniMax",
+                "description": "Provide a valid MiniMax API key. Get one at [platform.minimaxi.com](https://platform.minimaxi.com/).",
+                "sections": {
+                    "connection_section": {
+                        "name": "Connection",
+                        "description": "MiniMax authentication",
+                        "data": {
+                            "api_key": "API key"
+                        },
+                        "data_description": {
+                            "api_key": "Your MiniMax API key."
+                        }
+                    },
+                    "model_section": {
+                        "name": "Model",
+                        "description": "Set default model parameters",
+                        "data": {
+                            "default_model": "Default model",
+                            "temperature": "Temperature",
+                            "top_p": "Top P"
+                        },
+                        "data_description": {
+                            "default_model": "The default model to use when no other model is specified. Recommended: MiniMax-M1",
+                            "temperature": "Controls the randomness of the output. Lower values make the output more deterministic.",
+                            "top_p": "Controls the diversity of the output. Lower values make the output more focused."
+                        }
+                    }
+                }
+            },
             "settings": {
                 "title": "Settings",
                 "description": "Configure the LLM Vision integration. This entry is required before setting up other providers. If you wish to use the default settings, just press 'Submit'.",

--- a/custom_components/llmvision/translations/fr.json
+++ b/custom_components/llmvision/translations/fr.json
@@ -349,6 +349,36 @@
                     }
                 }
             },
+            "minimax": {
+                "title": "Configurer MiniMax",
+                "description": "Fournissez une clé API MiniMax valide. Obtenez-en une sur [platform.minimaxi.com](https://platform.minimaxi.com/).",
+                "sections": {
+                    "connection_section": {
+                        "name": "Connexion",
+                        "description": "Authentification MiniMax",
+                        "data": {
+                            "api_key": "Clé API"
+                        },
+                        "data_description": {
+                            "api_key": "Votre clé API MiniMax."
+                        }
+                    },
+                    "model_section": {
+                        "name": "Modèle",
+                        "description": "Définir les paramètres par défaut du modèle",
+                        "data": {
+                            "default_model": "Modèle par défaut",
+                            "temperature": "Température",
+                            "top_p": "Top P"
+                        },
+                        "data_description": {
+                            "default_model": "Le modèle par défaut à utiliser si aucun autre modèle n'est spécifié. Recommandé : MiniMax-M1",
+                            "temperature": "Contrôle l'aléatoire de la sortie. Des valeurs plus basses rendent la sortie plus déterministe.",
+                            "top_p": "Contrôle la diversité de la sortie. Des valeurs plus basses rendent la sortie plus ciblée."
+                        }
+                    }
+                }
+            },
             "settings": {
                 "title": "Paramètres",
                 "description": "Configurez l'intégration LLM Vision. Cette entrée est requise avant de configurer d'autres fournisseurs. Si vous souhaitez utiliser les paramètres par défaut, appuyez simplement sur 'Soumettre'.",

--- a/custom_components/llmvision/translations/hu.json
+++ b/custom_components/llmvision/translations/hu.json
@@ -349,6 +349,36 @@
                     }
                 }
             },
+            "minimax": {
+                "title": "MiniMax konfigurálása",
+                "description": "Adj meg egy érvényes MiniMax API-kulcsot. Szerezz egyet a [platform.minimaxi.com](https://platform.minimaxi.com/) oldalon.",
+                "sections": {
+                    "connection_section": {
+                        "name": "Kapcsolat",
+                        "description": "MiniMax hitelesítés",
+                        "data": {
+                            "api_key": "API-kulcs"
+                        },
+                        "data_description": {
+                            "api_key": "A MiniMax API-kulcsod."
+                        }
+                    },
+                    "model_section": {
+                        "name": "Modell",
+                        "description": "A modell alapértelmezéseinek beállítása",
+                        "data": {
+                            "default_model": "Alapértelmezett modell",
+                            "temperature": "Hőmérséklet",
+                            "top_p": "Magmintavétel"
+                        },
+                        "data_description": {
+                            "default_model": "Az alapértelmezettként használt modell, ha nincs másik megadva. Ajánlott: MiniMax-M1",
+                            "temperature": "A kimenet véletlenszerűségét szabályozza. Az alacsonyabb értékek determinisztikusabb kimenetet eredményeznek.",
+                            "top_p": "A kimenet sokféleségét szabályozza. Az alacsonyabb értékek fókuszáltabbá teszik a kimenetet."
+                        }
+                    }
+                }
+            },
             "settings": {
                 "title": "Beállítások",
                 "description": "Konfiguráld az LLM Vision integrációt. Ez a bejegyzés kötelező más szolgáltatók beállítása előtt. Ha az alapértelmezett beállításokat szeretnéd használni, kattints a „Mehet” gombra.",

--- a/custom_components/llmvision/translations/nl.json
+++ b/custom_components/llmvision/translations/nl.json
@@ -349,6 +349,36 @@
           }
         }
       },
+      "minimax": {
+        "title": "MiniMax configureren",
+        "description": "Voer een geldige MiniMax API-sleutel in. Verkrijg er een op [platform.minimaxi.com](https://platform.minimaxi.com/).",
+        "sections": {
+          "connection_section": {
+            "name": "Verbinding",
+            "description": "MiniMax authenticatie",
+            "data": {
+              "api_key": "API-sleutel"
+            },
+            "data_description": {
+              "api_key": "Uw MiniMax API-sleutel."
+            }
+          },
+          "model_section": {
+            "name": "Model",
+            "description": "Stel standaard modelparameters in",
+            "data": {
+              "default_model": "Standaardmodel",
+              "temperature": "Temperatuur",
+              "top_p": "Top P"
+            },
+            "data_description": {
+              "default_model": "Het standaardmodel dat wordt gebruikt wanneer geen ander model is gespecificeerd. Aanbevolen: MiniMax-M1",
+              "temperature": "Regelt de willekeurigheid van de uitvoer. Lagere waarden maken de uitvoer deterministischer.",
+              "top_p": "Regelt de diversiteit van de uitvoer. Lagere waarden maken de uitvoer gerichter."
+            }
+          }
+        }
+      },
       "settings": {
         "title": "Instellingen",
         "description": "Configureer de LLM Vision integratie. Deze invoer is vereist voordat u andere providers instelt. Als u de standaardinstellingen wilt gebruiken, drukt u gewoon op 'Verzenden'.",

--- a/custom_components/llmvision/translations/pl.json
+++ b/custom_components/llmvision/translations/pl.json
@@ -349,6 +349,36 @@
                     }
                 }
             },
+            "minimax": {
+                "title": "Skonfiguruj MiniMax",
+                "description": "Podaj poprawny klucz API MiniMax. Uzyskaj go na [platform.minimaxi.com](https://platform.minimaxi.com/).",
+                "sections": {
+                    "connection_section": {
+                        "name": "Połączenie",
+                        "description": "Autoryzacja MiniMax",
+                        "data": {
+                            "api_key": "Klucz API"
+                        },
+                        "data_description": {
+                            "api_key": "Twój klucz API MiniMax."
+                        }
+                    },
+                    "model_section": {
+                        "name": "Model",
+                        "description": "Ustaw domyślne parametry modelu",
+                        "data": {
+                            "default_model": "Domyślny model",
+                            "temperature": "Temperatura",
+                            "top_p": "Top P"
+                        },
+                        "data_description": {
+                            "default_model": "Domyślny model do użycia, gdy nie określono innego modelu. Zalecany: MiniMax-M1",
+                            "temperature": "Kontroluje losowość wyjścia. Niższe wartości sprawiają, że wyjście jest bardziej deterministyczne.",
+                            "top_p": "Kontroluje różnorodność wyjścia. Niższe wartości sprawiają, że wyjście jest bardziej skoncentrowane."
+                        }
+                    }
+                }
+            },
             "settings": {
                 "title": "Ustawienia",
                 "description": "Skonfiguruj integrację LLM Vision. Ten wpis jest wymagany przed skonfigurowaniem innych dostawców. Jeśli chcesz użyć domyślnych ustawień, po prostu naciśnij 'Wyślij'.",

--- a/custom_components/llmvision/translations/sk.json
+++ b/custom_components/llmvision/translations/sk.json
@@ -349,6 +349,36 @@
                     }
                 }
             },
+            "minimax": {
+                "title": "Konfigurácia MiniMax",
+                "description": "Zadajte platný MiniMax API kľúč. Získajte ho na [platform.minimaxi.com](https://platform.minimaxi.com/).",
+                "sections": {
+                    "connection_section": {
+                        "name": "Pripojenie",
+                        "description": "MiniMax autentifikácia",
+                        "data": {
+                            "api_key": "API kľúč"
+                        },
+                        "data_description": {
+                            "api_key": "Váš MiniMax API kľúč."
+                        }
+                    },
+                    "model_section": {
+                        "name": "Model",
+                        "description": "Nastavte predvolené parametre modelu",
+                        "data": {
+                            "default_model": "Predvolený model",
+                            "temperature": "Teplota",
+                            "top_p": "Top P"
+                        },
+                        "data_description": {
+                            "default_model": "Predvolený model, ktorý sa použije, ak nie je špecifikovaný iný. Odporúčaný: MiniMax-M1",
+                            "temperature": "Ovláda náhodnosť výstupu. Nižšie hodnoty znamenajú deterministickejší výstup.",
+                            "top_p": "Ovláda rozmanitosť výstupu. Nižšie hodnoty znamenajú zameranejší výstup."
+                        }
+                    }
+                }
+            },
             "settings": {
                 "title": "Nastavenia",
                 "description": "Nakonfigurujte integráciu LLM Vision. Tento záznam je potrebný pred nastavením iných poskytovateľov. Ak chcete použiť predvolené nastavenia, stačí stlačiť 'Odoslať'.",

--- a/custom_components/llmvision/translations/sv.json
+++ b/custom_components/llmvision/translations/sv.json
@@ -349,6 +349,36 @@
                     }
                 }
             },
+            "minimax": {
+                "title": "Konfigurera MiniMax",
+                "description": "Ange en giltig MiniMax API-nyckel. Skaffa en på [platform.minimaxi.com](https://platform.minimaxi.com/).",
+                "sections": {
+                    "connection_section": {
+                        "name": "Anslutning",
+                        "description": "MiniMax-autentisering",
+                        "data": {
+                            "api_key": "API-nyckel"
+                        },
+                        "data_description": {
+                            "api_key": "Din MiniMax API-nyckel."
+                        }
+                    },
+                    "model_section": {
+                        "name": "Modell",
+                        "description": "Ställ in standardmodellparametrar",
+                        "data": {
+                            "default_model": "Standardmodell",
+                            "temperature": "Temperatur",
+                            "top_p": "Top P"
+                        },
+                        "data_description": {
+                            "default_model": "Standardmodellen som används om ingen annan anges. Rekommenderad: MiniMax-M1",
+                            "temperature": "Styr slumpmässigheten i svaret. Lägre värden ger mer deterministiska svar.",
+                            "top_p": "Styr mångfalden i svaret. Lägre värden ger mer fokuserade svar."
+                        }
+                    }
+                }
+            },
             "settings": {
                 "title": "Inställningar",
                 "description": "Konfigurera LLM Vision-integrationen. Detta måste göras innan du lägger till andra leverantörer. Om du vill använda standardinställningarna, tryck bara på 'Skicka'.",

--- a/custom_components/llmvision/translations/tr.json
+++ b/custom_components/llmvision/translations/tr.json
@@ -349,6 +349,36 @@
                     }
                 }
             },
+            "minimax": {
+                "title": "MiniMax Yapılandırması",
+                "description": "Geçerli bir MiniMax API anahtarı girin. [platform.minimaxi.com](https://platform.minimaxi.com/) adresinden edinin.",
+                "sections": {
+                    "connection_section": {
+                        "name": "Bağlantı",
+                        "description": "MiniMax kimlik doğrulama",
+                        "data": {
+                            "api_key": "API anahtarı"
+                        },
+                        "data_description": {
+                            "api_key": "MiniMax API anahtarınız."
+                        }
+                    },
+                    "model_section": {
+                        "name": "Model",
+                        "description": "Varsayılan model parametrelerini ayarlayın",
+                        "data": {
+                            "default_model": "Varsayılan model",
+                            "temperature": "Sıcaklık",
+                            "top_p": "Top P"
+                        },
+                        "data_description": {
+                            "default_model": "Başka bir model belirtilmediğinde kullanılacak varsayılan model. Önerilen: MiniMax-M1",
+                            "temperature": "Çıktının rastgeleliğini kontrol eder. Düşük değerler çıktıyı daha belirleyici yapar.",
+                            "top_p": "Çıktının çeşitliliğini kontrol eder. Düşük değerler çıktıyı daha odaklı yapar."
+                        }
+                    }
+                }
+            },
             "settings": {
                 "title": "Ayarlar",
                 "description": "LLM Vision entegrasyonunu yapılandırın. Bu giriş, diğer sağlayıcıları kurmadan önce gereklidir. Varsayılan ayarları kullanmak istiyorsanız, sadece 'Gönder' butonuna basın.",

--- a/tests/test_minimax_standalone.py
+++ b/tests/test_minimax_standalone.py
@@ -1,0 +1,465 @@
+"""Standalone tests for MiniMax provider integration.
+
+These tests mock homeassistant dependencies and directly load only the modules
+needed for testing, bypassing __init__.py which uses Python 3.12+ syntax.
+"""
+import sys
+import os
+import json
+import types
+import asyncio
+import importlib
+import unittest
+from unittest.mock import Mock, AsyncMock, patch, MagicMock
+
+
+# --- Mock homeassistant modules before importing component code ---
+
+def _setup_ha_mocks():
+    """Create mock homeassistant modules for testing."""
+    ha_exceptions = types.ModuleType("homeassistant.exceptions")
+
+    class ServiceValidationError(Exception):
+        pass
+
+    ha_exceptions.ServiceValidationError = ServiceValidationError
+
+    ha = types.ModuleType("homeassistant")
+    ha.__path__ = []
+
+    ha_helpers = types.ModuleType("homeassistant.helpers")
+    ha_helpers.__path__ = []
+    ha_helpers_aiohttp = types.ModuleType("homeassistant.helpers.aiohttp_client")
+    ha_helpers_aiohttp.async_get_clientsession = Mock(return_value=Mock())
+
+    ha_core = types.ModuleType("homeassistant.core")
+    ha_core.HomeAssistant = type("HomeAssistant", (), {})
+
+    ha_config_entries = types.ModuleType("homeassistant.config_entries")
+    ha_config_entries.ConfigEntry = type("ConfigEntry", (), {})
+
+    mods = {
+        "homeassistant": ha,
+        "homeassistant.exceptions": ha_exceptions,
+        "homeassistant.helpers": ha_helpers,
+        "homeassistant.helpers.aiohttp_client": ha_helpers_aiohttp,
+        "homeassistant.core": ha_core,
+        "homeassistant.config_entries": ha_config_entries,
+    }
+    sys.modules.update(mods)
+
+    if "boto3" not in sys.modules:
+        sys.modules["boto3"] = MagicMock()
+
+    return ServiceValidationError
+
+
+ServiceValidationError = _setup_ha_mocks()
+
+# Prevent __init__.py from running; create a stub package
+_pkg_name = "custom_components.llmvision"
+_pkg = types.ModuleType(_pkg_name)
+_pkg.__path__ = [os.path.join(os.path.dirname(__file__), "..", "custom_components", "llmvision")]
+_pkg.__package__ = _pkg_name
+sys.modules.setdefault("custom_components", types.ModuleType("custom_components"))
+sys.modules["custom_components"].__path__ = [os.path.join(os.path.dirname(__file__), "..", "custom_components")]
+sys.modules[_pkg_name] = _pkg
+
+# Now load const and providers directly
+import importlib.util
+
+_base_dir = os.path.join(os.path.dirname(__file__), "..", "custom_components", "llmvision")
+
+def _load_module(name, filepath):
+    spec = importlib.util.spec_from_file_location(
+        f"custom_components.llmvision.{name}",
+        os.path.join(_base_dir, filepath),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[f"custom_components.llmvision.{name}"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+const_mod = _load_module("const", "const.py")
+providers_mod = _load_module("providers", "providers.py")
+
+# Pull out what we need
+DOMAIN = const_mod.DOMAIN
+DEFAULT_MINIMAX_MODEL = const_mod.DEFAULT_MINIMAX_MODEL
+ENDPOINT_MINIMAX = const_mod.ENDPOINT_MINIMAX
+DEFAULT_OPENAI_MODEL = const_mod.DEFAULT_OPENAI_MODEL
+OpenAI = providers_mod.OpenAI
+Request = providers_mod.Request
+ProviderFactory = providers_mod.ProviderFactory
+
+
+def _make_mock_hass():
+    hass = Mock()
+    hass.data = {}
+    hass.config_entries = Mock()
+    hass.config_entries.async_entries = Mock(return_value=[])
+    hass.loop = Mock()
+    hass.loop.run_in_executor = AsyncMock()
+    hass.config = Mock()
+    hass.config.path = Mock(return_value="/mock/path")
+    return hass
+
+
+class TestMiniMaxConstants(unittest.TestCase):
+    """Test MiniMax constants."""
+
+    def test_default_model(self):
+        self.assertEqual(DEFAULT_MINIMAX_MODEL, "MiniMax-M1")
+
+    def test_endpoint(self):
+        self.assertEqual(ENDPOINT_MINIMAX, "https://api.minimax.io/v1/chat/completions")
+
+    def test_endpoint_is_openai_compatible(self):
+        self.assertTrue(ENDPOINT_MINIMAX.endswith("/v1/chat/completions"))
+
+
+class TestMiniMaxProviderFactory(unittest.TestCase):
+    """Test ProviderFactory creates MiniMax provider correctly."""
+
+    def test_create_minimax(self):
+        hass = _make_mock_hass()
+        provider = ProviderFactory.create(hass, "MiniMax", {"api_key": "test_key"}, "MiniMax-M1")
+
+        self.assertIsNotNone(provider)
+        self.assertIsInstance(provider, OpenAI)
+        self.assertEqual(provider.model, "MiniMax-M1")
+        self.assertEqual(provider.api_key, "test_key")
+
+    def test_create_minimax_endpoint(self):
+        hass = _make_mock_hass()
+        provider = ProviderFactory.create(hass, "MiniMax", {"api_key": "test_key"}, "MiniMax-M1")
+
+        self.assertEqual(provider.endpoint.get("base_url"), ENDPOINT_MINIMAX)
+
+    def test_create_minimax_empty_key(self):
+        hass = _make_mock_hass()
+        provider = ProviderFactory.create(hass, "MiniMax", {}, "MiniMax-M1")
+
+        self.assertEqual(provider.api_key, "")
+
+    def test_create_invalid_provider(self):
+        hass = _make_mock_hass()
+
+        with self.assertRaises(ServiceValidationError):
+            ProviderFactory.create(hass, "InvalidProvider", {"api_key": "test"}, "model")
+
+
+class TestMiniMaxDefaultModel(unittest.TestCase):
+    """Test MiniMax default model mapping."""
+
+    def test_default_model_mapping(self):
+        hass = _make_mock_hass()
+        hass.data = {DOMAIN: {"entry": {"provider": "MiniMax"}}}
+
+        request = Request(hass, "test", 1000, 0.5)
+        self.assertEqual(request.get_default_model("entry"), DEFAULT_MINIMAX_MODEL)
+
+    def test_default_model_from_config(self):
+        hass = _make_mock_hass()
+        hass.data = {DOMAIN: {"entry": {"provider": "MiniMax", "default_model": "MiniMax-M1"}}}
+
+        request = Request(hass, "test", 1000, 0.5)
+        self.assertEqual(request.get_default_model("entry"), "MiniMax-M1")
+
+    def test_openai_default_model_still_works(self):
+        hass = _make_mock_hass()
+        hass.data = {DOMAIN: {"entry": {"provider": "OpenAI"}}}
+
+        request = Request(hass, "test", 1000, 0.5)
+        self.assertEqual(request.get_default_model("entry"), DEFAULT_OPENAI_MODEL)
+
+
+class TestMiniMaxProviderBehavior(unittest.TestCase):
+    """Test MiniMax provider behavior (inherits from OpenAI)."""
+
+    def _create_provider(self, api_key="test_key", model="MiniMax-M1"):
+        hass = _make_mock_hass()
+        return ProviderFactory.create(hass, "MiniMax", {"api_key": api_key}, model), hass
+
+    def test_supports_structured_output(self):
+        provider, _ = self._create_provider()
+        self.assertTrue(provider.supports_structured_output())
+
+    def test_generate_headers(self):
+        provider, _ = self._create_provider(api_key="minimax_api_key_123")
+        headers = provider._generate_headers()
+
+        self.assertEqual(headers["Content-type"], "application/json")
+        self.assertEqual(headers["Authorization"], "Bearer minimax_api_key_123")
+
+    def test_prepare_vision_data(self):
+        provider, hass = self._create_provider()
+
+        call = Mock()
+        call.max_tokens = 1000
+        call.base64_images = ["base64_image_data"]
+        call.filenames = ["test.jpg"]
+        call.message = "Describe this image"
+        call.provider = "test_provider"
+        call.response_format = "text"
+        call.use_memory = False
+
+        hass.data = {DOMAIN: {"test_provider": {"provider": "MiniMax", "temperature": 0.5, "top_p": 0.9}}}
+
+        with patch.object(provider, '_get_system_prompt', return_value="System prompt"):
+            result = provider._prepare_vision_data(call)
+
+        self.assertEqual(result["model"], "MiniMax-M1")
+        self.assertEqual(result["max_completion_tokens"], 1000)
+        self.assertEqual(len(result["messages"]), 2)
+        self.assertEqual(result["messages"][0]["role"], "system")
+        self.assertEqual(result["messages"][1]["role"], "user")
+
+        # Check image is included
+        user_content = result["messages"][1]["content"]
+        has_image = any(isinstance(item, dict) and item.get("type") == "image_url" for item in user_content)
+        self.assertTrue(has_image)
+
+    def test_prepare_text_data(self):
+        provider, hass = self._create_provider()
+
+        call = Mock()
+        call.max_tokens = 1000
+        call.message = "Generate a title"
+        call.provider = "test_provider"
+
+        hass.data = {DOMAIN: {"test_provider": {"provider": "MiniMax", "temperature": 0.5, "top_p": 0.9}}}
+
+        with patch.object(provider, '_get_title_prompt', return_value="Title prompt"):
+            result = provider._prepare_text_data(call)
+
+        self.assertEqual(result["model"], "MiniMax-M1")
+        self.assertEqual(result["max_completion_tokens"], 1000)
+        self.assertEqual(len(result["messages"]), 2)
+
+    def test_prepare_vision_data_with_structured_output(self):
+        provider, hass = self._create_provider()
+
+        call = Mock()
+        call.max_tokens = 1000
+        call.base64_images = ["base64_image_data"]
+        call.filenames = ["test.jpg"]
+        call.message = "Extract data"
+        call.provider = "test_provider"
+        call.response_format = "json"
+        call.structure = '{"type": "object", "properties": {"count": {"type": "integer"}}}'
+        call.use_memory = False
+
+        hass.data = {DOMAIN: {"test_provider": {"provider": "MiniMax", "temperature": 0.5, "top_p": 0.9}}}
+
+        with patch.object(provider, '_get_system_prompt', return_value="System prompt"):
+            result = provider._prepare_vision_data(call)
+
+        self.assertIn("response_format", result)
+        self.assertEqual(result["response_format"]["type"], "json_schema")
+        self.assertTrue(result["response_format"]["json_schema"]["strict"])
+
+    def test_prepare_vision_data_multiple_images(self):
+        provider, hass = self._create_provider()
+
+        call = Mock()
+        call.max_tokens = 1000
+        call.base64_images = ["img1", "img2", "img3"]
+        call.filenames = ["cam1.jpg", "cam2.jpg", "cam3.jpg"]
+        call.message = "What do you see?"
+        call.provider = "test_provider"
+        call.response_format = "text"
+        call.use_memory = False
+
+        hass.data = {DOMAIN: {"test_provider": {"provider": "MiniMax", "temperature": 0.5, "top_p": 0.9}}}
+
+        with patch.object(provider, '_get_system_prompt', return_value="System prompt"):
+            result = provider._prepare_vision_data(call)
+
+        user_content = result["messages"][1]["content"]
+        image_items = [item for item in user_content if isinstance(item, dict) and item.get("type") == "image_url"]
+        self.assertEqual(len(image_items), 3)
+
+    def test_temperature_and_top_p_passed(self):
+        provider, hass = self._create_provider()
+
+        call = Mock()
+        call.max_tokens = 500
+        call.base64_images = ["img"]
+        call.filenames = ["test.jpg"]
+        call.message = "test"
+        call.provider = "test_provider"
+        call.response_format = "text"
+        call.use_memory = False
+
+        hass.data = {DOMAIN: {"test_provider": {"provider": "MiniMax", "temperature": 0.3, "top_p": 0.7}}}
+
+        with patch.object(provider, '_get_system_prompt', return_value="System prompt"):
+            result = provider._prepare_vision_data(call)
+
+        self.assertEqual(result["temperature"], 0.3)
+        self.assertEqual(result["top_p"], 0.7)
+
+
+class TestMiniMaxAsyncOperations(unittest.TestCase):
+    """Test MiniMax async operations."""
+
+    def _create_provider(self, api_key="test_key", model="MiniMax-M1"):
+        hass = _make_mock_hass()
+        return ProviderFactory.create(hass, "MiniMax", {"api_key": api_key}, model), hass
+
+    def test_make_request(self):
+        provider, _ = self._create_provider()
+
+        mock_response = {"choices": [{"message": {"content": "A person walking a dog."}}]}
+
+        async def run():
+            with patch.object(provider, '_post', new_callable=AsyncMock, return_value=mock_response):
+                return await provider._make_request({"model": "MiniMax-M1", "messages": []})
+
+        result = asyncio.get_event_loop().run_until_complete(run())
+        self.assertEqual(result, "A person walking a dog.")
+
+    def test_make_request_empty_response(self):
+        provider, _ = self._create_provider()
+
+        mock_response = {"choices": []}
+
+        async def run():
+            with patch.object(provider, '_post', new_callable=AsyncMock, return_value=mock_response):
+                with self.assertRaises(ServiceValidationError):
+                    await provider._make_request({"model": "MiniMax-M1", "messages": []})
+
+        asyncio.get_event_loop().run_until_complete(run())
+
+    def test_validate_success(self):
+        provider, _ = self._create_provider(api_key="valid_key")
+
+        mock_response = {"choices": [{"message": {"content": "Hi"}}]}
+
+        async def run():
+            with patch.object(provider, '_post', new_callable=AsyncMock, return_value=mock_response):
+                await provider.validate()
+
+        asyncio.get_event_loop().run_until_complete(run())
+
+    def test_validate_empty_key(self):
+        provider, _ = self._create_provider(api_key="")
+
+        async def run():
+            with self.assertRaises(ServiceValidationError):
+                await provider.validate()
+
+        asyncio.get_event_loop().run_until_complete(run())
+
+    def test_vision_request_flow(self):
+        provider, hass = self._create_provider()
+
+        call = Mock()
+        call.max_tokens = 1000
+        call.base64_images = ["base64img"]
+        call.filenames = ["test.jpg"]
+        call.message = "Analyze"
+        call.provider = "test_provider"
+        call.response_format = "text"
+        call.use_memory = False
+
+        hass.data = {DOMAIN: {"test_provider": {"provider": "MiniMax", "temperature": 0.5, "top_p": 0.9}}}
+
+        mock_response = {"choices": [{"message": {"content": "Analysis result"}}]}
+
+        async def run():
+            with patch.object(provider, '_post', new_callable=AsyncMock, return_value=mock_response):
+                with patch.object(provider, '_get_system_prompt', return_value="System prompt"):
+                    return await provider.vision_request(call)
+
+        result = asyncio.get_event_loop().run_until_complete(run())
+        self.assertEqual(result, "Analysis result")
+
+
+class TestMiniMaxTranslations(unittest.TestCase):
+    """Test MiniMax translation entries."""
+
+    def _get_translations_dir(self):
+        return os.path.join(os.path.dirname(__file__), "..", "custom_components", "llmvision", "translations")
+
+    def test_english_translation_exists(self):
+        with open(os.path.join(self._get_translations_dir(), "en.json")) as f:
+            data = json.load(f)
+
+        steps = data["config"]["step"]
+        self.assertIn("minimax", steps)
+        self.assertEqual(steps["minimax"]["title"], "Configure MiniMax")
+        self.assertIn("connection_section", steps["minimax"]["sections"])
+        self.assertIn("model_section", steps["minimax"]["sections"])
+
+    def test_all_translations_have_minimax(self):
+        for fname in os.listdir(self._get_translations_dir()):
+            if not fname.endswith(".json"):
+                continue
+            fpath = os.path.join(self._get_translations_dir(), fname)
+            with open(fpath) as f:
+                data = json.load(f)
+
+            steps = data.get("config", {}).get("step", {})
+            self.assertIn("minimax", steps, f"Missing minimax step in {fname}")
+            self.assertIn("title", steps["minimax"], f"Missing title in {fname}")
+            self.assertIn("connection_section", steps["minimax"].get("sections", {}), f"Missing connection_section in {fname}")
+            self.assertIn("model_section", steps["minimax"].get("sections", {}), f"Missing model_section in {fname}")
+
+    def test_all_translation_files_valid_json(self):
+        for fname in os.listdir(self._get_translations_dir()):
+            if not fname.endswith(".json"):
+                continue
+            fpath = os.path.join(self._get_translations_dir(), fname)
+            with open(fpath) as f:
+                try:
+                    json.load(f)
+                except json.JSONDecodeError as e:
+                    self.fail(f"Invalid JSON in {fname}: {e}")
+
+
+class TestMiniMaxCodeIntegration(unittest.TestCase):
+    """Integration tests for MiniMax presence in source files."""
+
+    def _read_file(self, relpath):
+        path = os.path.join(os.path.dirname(__file__), "..", relpath)
+        with open(path) as f:
+            return f.read()
+
+    def test_minimax_in_const(self):
+        content = self._read_file("custom_components/llmvision/const.py")
+        self.assertIn("DEFAULT_MINIMAX_MODEL", content)
+        self.assertIn("ENDPOINT_MINIMAX", content)
+
+    def test_minimax_in_providers(self):
+        content = self._read_file("custom_components/llmvision/providers.py")
+        self.assertIn("MiniMax", content)
+        self.assertIn("ENDPOINT_MINIMAX", content)
+        self.assertIn("DEFAULT_MINIMAX_MODEL", content)
+
+    def test_minimax_in_config_flow(self):
+        content = self._read_file("custom_components/llmvision/config_flow.py")
+        self.assertIn('"MiniMax"', content)
+        self.assertIn("async_step_minimax", content)
+        self.assertIn("ENDPOINT_MINIMAX", content)
+        self.assertIn("DEFAULT_MINIMAX_MODEL", content)
+
+    def test_minimax_in_readme(self):
+        content = self._read_file("README.md")
+        self.assertIn("MiniMax", content)
+
+    def test_minimax_in_provider_dropdown(self):
+        """Verify MiniMax is in the provider selection dropdown list."""
+        content = self._read_file("custom_components/llmvision/config_flow.py")
+        # Find the options list in async_step_user
+        self.assertIn('"MiniMax",', content)
+
+    def test_minimax_in_handle_provider_map(self):
+        """Verify MiniMax is in the handle_provider routing dict."""
+        content = self._read_file("custom_components/llmvision/config_flow.py")
+        self.assertIn('"MiniMax": self.async_step_minimax', content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -656,3 +656,313 @@ class TestProviderFactory:
             
             assert provider is not None
             assert provider.model == "llama2"
+
+    def test_create_minimax(self, mock_hass_with_session):
+        """Test ProviderFactory creates MiniMax provider."""
+        from custom_components.llmvision.providers import ProviderFactory
+
+        config = {"api_key": "test_key"}
+
+        with patch('custom_components.llmvision.providers.async_get_clientsession'):
+            provider = ProviderFactory.create(
+                mock_hass_with_session,
+                "MiniMax",
+                config,
+                "MiniMax-M1"
+            )
+
+            assert provider is not None
+            assert provider.model == "MiniMax-M1"
+            assert isinstance(provider, OpenAI)
+
+    def test_create_minimax_endpoint(self, mock_hass_with_session):
+        """Test ProviderFactory creates MiniMax provider with correct endpoint."""
+        from custom_components.llmvision.providers import ProviderFactory
+        from custom_components.llmvision.const import ENDPOINT_MINIMAX
+
+        config = {"api_key": "test_key"}
+
+        with patch('custom_components.llmvision.providers.async_get_clientsession'):
+            provider = ProviderFactory.create(
+                mock_hass_with_session,
+                "MiniMax",
+                config,
+                "MiniMax-M1"
+            )
+
+            assert provider.endpoint.get("base_url") == ENDPOINT_MINIMAX
+
+    def test_create_invalid_provider(self, mock_hass_with_session):
+        """Test ProviderFactory raises error for invalid provider."""
+        from custom_components.llmvision.providers import ProviderFactory
+
+        config = {"api_key": "test_key"}
+
+        with patch('custom_components.llmvision.providers.async_get_clientsession'):
+            with pytest.raises(ServiceValidationError):
+                ProviderFactory.create(
+                    mock_hass_with_session,
+                    "InvalidProvider",
+                    config,
+                    "model"
+                )
+
+
+class TestMiniMax:
+    """Test MiniMax provider (reuses OpenAI class via ProviderFactory)."""
+
+    def test_minimax_is_openai_instance(self, mock_hass_with_session):
+        """Test MiniMax provider is an instance of OpenAI."""
+        from custom_components.llmvision.providers import ProviderFactory
+        from custom_components.llmvision.const import ENDPOINT_MINIMAX
+
+        config = {"api_key": "minimax_test_key"}
+
+        with patch('custom_components.llmvision.providers.async_get_clientsession'):
+            provider = ProviderFactory.create(
+                mock_hass_with_session,
+                "MiniMax",
+                config,
+                "MiniMax-M1"
+            )
+
+            assert isinstance(provider, OpenAI)
+            assert provider.api_key == "minimax_test_key"
+            assert provider.model == "MiniMax-M1"
+            assert provider.endpoint.get("base_url") == ENDPOINT_MINIMAX
+
+    def test_minimax_supports_structured_output(self, mock_hass_with_session):
+        """Test MiniMax provider supports structured output (inherits from OpenAI)."""
+        from custom_components.llmvision.providers import ProviderFactory
+
+        config = {"api_key": "test_key"}
+
+        with patch('custom_components.llmvision.providers.async_get_clientsession'):
+            provider = ProviderFactory.create(
+                mock_hass_with_session,
+                "MiniMax",
+                config,
+                "MiniMax-M1"
+            )
+
+            assert provider.supports_structured_output() is True
+
+    def test_minimax_generate_headers(self, mock_hass_with_session):
+        """Test MiniMax provider generates correct headers."""
+        from custom_components.llmvision.providers import ProviderFactory
+
+        config = {"api_key": "minimax_api_key_123"}
+
+        with patch('custom_components.llmvision.providers.async_get_clientsession'):
+            provider = ProviderFactory.create(
+                mock_hass_with_session,
+                "MiniMax",
+                config,
+                "MiniMax-M1"
+            )
+
+            headers = provider._generate_headers()
+
+            assert headers["Content-type"] == "application/json"
+            assert headers["Authorization"] == "Bearer minimax_api_key_123"
+
+    def test_minimax_prepare_vision_data(self, mock_hass_with_session):
+        """Test MiniMax provider prepares vision data correctly."""
+        from custom_components.llmvision.providers import ProviderFactory
+
+        config = {"api_key": "test_key"}
+
+        with patch('custom_components.llmvision.providers.async_get_clientsession'):
+            provider = ProviderFactory.create(
+                mock_hass_with_session,
+                "MiniMax",
+                config,
+                "MiniMax-M1"
+            )
+            call = Mock()
+            call.max_tokens = 1000
+            call.base64_images = ["base64_image_data"]
+            call.filenames = ["test.jpg"]
+            call.message = "Describe this image"
+            call.provider = "test_provider"
+            call.response_format = "text"
+            call.use_memory = False
+
+            mock_hass_with_session.data = {
+                DOMAIN: {
+                    "test_provider": {
+                        "provider": "MiniMax",
+                        "temperature": 0.5,
+                        "top_p": 0.9
+                    }
+                }
+            }
+
+            with patch.object(provider, '_get_system_prompt', return_value="System prompt"):
+                result = provider._prepare_vision_data(call)
+
+            assert result["model"] == "MiniMax-M1"
+            assert result["max_completion_tokens"] == 1000
+            assert len(result["messages"]) == 2  # system + user
+            assert result["messages"][0]["role"] == "system"
+            assert result["messages"][1]["role"] == "user"
+
+    def test_minimax_prepare_text_data(self, mock_hass_with_session):
+        """Test MiniMax provider prepares text data correctly."""
+        from custom_components.llmvision.providers import ProviderFactory
+
+        config = {"api_key": "test_key"}
+
+        with patch('custom_components.llmvision.providers.async_get_clientsession'):
+            provider = ProviderFactory.create(
+                mock_hass_with_session,
+                "MiniMax",
+                config,
+                "MiniMax-M1"
+            )
+            call = Mock()
+            call.max_tokens = 1000
+            call.message = "Generate a title"
+            call.provider = "test_provider"
+
+            mock_hass_with_session.data = {
+                DOMAIN: {
+                    "test_provider": {
+                        "provider": "MiniMax",
+                        "temperature": 0.5,
+                        "top_p": 0.9
+                    }
+                }
+            }
+
+            with patch.object(provider, '_get_title_prompt', return_value="Title prompt"):
+                result = provider._prepare_text_data(call)
+
+            assert result["model"] == "MiniMax-M1"
+            assert result["max_completion_tokens"] == 1000
+            assert len(result["messages"]) == 2
+
+    def test_minimax_default_model(self, mock_hass_with_session):
+        """Test MiniMax default model is correctly mapped."""
+        from custom_components.llmvision.const import DEFAULT_MINIMAX_MODEL
+
+        mock_hass_with_session.data = {
+            DOMAIN: {
+                "minimax_entry": {
+                    "provider": "MiniMax"
+                }
+            }
+        }
+
+        with patch('custom_components.llmvision.providers.async_get_clientsession'):
+            request = Request(mock_hass_with_session, "test", 1000, 0.5)
+            result = request.get_default_model("minimax_entry")
+            assert result == DEFAULT_MINIMAX_MODEL
+
+    @pytest.mark.asyncio
+    async def test_minimax_make_request(self, mock_hass_with_session):
+        """Test MiniMax provider makes request and parses response."""
+        from custom_components.llmvision.providers import ProviderFactory
+
+        config = {"api_key": "test_key"}
+
+        with patch('custom_components.llmvision.providers.async_get_clientsession'):
+            provider = ProviderFactory.create(
+                mock_hass_with_session,
+                "MiniMax",
+                config,
+                "MiniMax-M1"
+            )
+
+            mock_response = {
+                "choices": [
+                    {
+                        "message": {
+                            "content": "A person walking a dog in the park."
+                        }
+                    }
+                ]
+            }
+
+            with patch.object(provider, '_post', new_callable=AsyncMock, return_value=mock_response):
+                result = await provider._make_request({"model": "MiniMax-M1", "messages": []})
+
+            assert result == "A person walking a dog in the park."
+
+    @pytest.mark.asyncio
+    async def test_minimax_validate_success(self, mock_hass_with_session):
+        """Test MiniMax provider validation succeeds."""
+        from custom_components.llmvision.providers import ProviderFactory
+
+        config = {"api_key": "valid_key"}
+
+        with patch('custom_components.llmvision.providers.async_get_clientsession'):
+            provider = ProviderFactory.create(
+                mock_hass_with_session,
+                "MiniMax",
+                config,
+                "MiniMax-M1"
+            )
+
+            mock_response = {"choices": [{"message": {"content": "Hi"}}]}
+
+            with patch.object(provider, '_post', new_callable=AsyncMock, return_value=mock_response):
+                await provider.validate()
+
+    @pytest.mark.asyncio
+    async def test_minimax_validate_empty_key(self, mock_hass_with_session):
+        """Test MiniMax provider validation fails with empty key."""
+        from custom_components.llmvision.providers import ProviderFactory
+
+        config = {"api_key": ""}
+
+        with patch('custom_components.llmvision.providers.async_get_clientsession'):
+            provider = ProviderFactory.create(
+                mock_hass_with_session,
+                "MiniMax",
+                config,
+                "MiniMax-M1"
+            )
+
+            with pytest.raises(ServiceValidationError):
+                await provider.validate()
+
+    def test_minimax_vision_data_with_structured_output(self, mock_hass_with_session):
+        """Test MiniMax prepares vision data with JSON schema structured output."""
+        from custom_components.llmvision.providers import ProviderFactory
+
+        config = {"api_key": "test_key"}
+
+        with patch('custom_components.llmvision.providers.async_get_clientsession'):
+            provider = ProviderFactory.create(
+                mock_hass_with_session,
+                "MiniMax",
+                config,
+                "MiniMax-M1"
+            )
+            call = Mock()
+            call.max_tokens = 1000
+            call.base64_images = ["base64_image_data"]
+            call.filenames = ["test.jpg"]
+            call.message = "Extract data"
+            call.provider = "test_provider"
+            call.response_format = "json"
+            call.structure = '{"type": "object", "properties": {"count": {"type": "integer"}}}'
+            call.use_memory = False
+
+            mock_hass_with_session.data = {
+                DOMAIN: {
+                    "test_provider": {
+                        "provider": "MiniMax",
+                        "temperature": 0.5,
+                        "top_p": 0.9
+                    }
+                }
+            }
+
+            with patch.object(provider, '_get_system_prompt', return_value="System prompt"):
+                result = provider._prepare_vision_data(call)
+
+            assert "response_format" in result
+            assert result["response_format"]["type"] == "json_schema"
+            assert result["response_format"]["json_schema"]["strict"] is True


### PR DESCRIPTION
## Summary

[MiniMax](https://www.minimaxi.com/) is a leading AI company that offers powerful multimodal models (MiniMax-M1) with an OpenAI-compatible API.

This PR adds MiniMax as a dedicated provider in LLM Vision, giving users a seamless setup experience:

- **Provider integration**: MiniMax appears in the provider dropdown alongside OpenAI, Anthropic, Google, etc.
- **OpenAI-compatible**: Reuses the existing OpenAI class via ProviderFactory (same pattern as OpenRouter), so vision analysis, title generation, structured output, and memory all work out of the box.
- **Full i18n**: MiniMax configuration step added to all 12 translation files (en, de, fr, cn, ca, cs, hu, nl, pl, sk, sv, tr).
- **Default model**: MiniMax-M1 (their latest multimodal model with vision capabilities).
- **API endpoint**: https://api.minimax.io/v1/chat/completions

## Files Changed (18 files, ~790 additions)

| File | Change |
|------|--------|
| const.py | Add DEFAULT_MINIMAX_MODEL, ENDPOINT_MINIMAX |
| providers.py | Register MiniMax in ProviderFactory + default model map |
| config_flow.py | Add MiniMax to dropdown + async_step_minimax() |
| translations/*.json | Add MiniMax step in all 12 languages |
| README.md | List MiniMax in supported providers |
| tests/test_providers.py | Unit tests for MiniMax factory + provider behavior |
| tests/test_minimax_standalone.py | 31 standalone tests |

## Test Plan

- [x] 31 standalone tests all pass
- [x] Provider factory creates MiniMax as OpenAI instance with correct endpoint
- [x] Headers, vision data, text data, structured output all verified
- [x] Validate rejects empty API key
- [x] All 12 translation files contain valid MiniMax entries
- [ ] CI tests will verify full integration with HA test framework (Python 3.13)
