### PR TITLE
Add llm_pick_keyframe option for LLM-guided keyframe selection

### DIFF
--- a/custom_components/llmvision/__init__.py
+++ b/custom_components/llmvision/__init__.py
@@ -54,6 +54,7 @@ from .const import (
     MAX_FRAMES,
     INCLUDE_FILENAME,
     EXPOSE_IMAGES,
+    LLM_PICK_KEYFRAME,
     GENERATE_TITLE,
     SENSOR_ENTITY,
     DATA_EXTRACTION_PROMPT,
@@ -468,6 +469,7 @@ class ServiceCallData:
         self.max_tokens = int(data_call.data.get(MAXTOKENS, 3000))
         self.include_filename = data_call.data.get(INCLUDE_FILENAME, False)
         self.expose_images = data_call.data.get(EXPOSE_IMAGES, False)
+        self.llm_pick_keyframe = data_call.data.get(LLM_PICK_KEYFRAME, False)
         self.generate_title = data_call.data.get(GENERATE_TITLE, False)
         self.sensor_entity = data_call.data.get(SENSOR_ENTITY, "")
         self.response_format = data_call.data.get(RESPONSE_FORMAT, "text")
@@ -520,6 +522,42 @@ class ServiceCallData:
 
     def get_service_call_data(self):
         return self
+
+
+def _extract_best_frame(response, candidate_frames):
+    """Extract best_frame label from LLM response and return matching index.
+
+    Returns the index into candidate_frames, or None if no valid match found.
+    """
+    best_frame_label = None
+
+    # Check structured response first
+    structured = response.get("structured_response")
+    if structured and isinstance(structured, dict):
+        best_frame_label = structured.get("best_frame")
+
+    # Fall back to regex parsing of text response
+    if not best_frame_label:
+        response_text = response.get("response_text", "")
+        if response_text:
+            match = re.search(r'best_frame["\s:]+([^\n"]+)', response_text)
+            if match:
+                best_frame_label = match.group(1).strip().strip('"').strip("'")
+
+    if not best_frame_label:
+        return None
+
+    # Exact match against candidate labels
+    for idx, (label, _, _) in enumerate(candidate_frames):
+        if label == best_frame_label:
+            return idx
+
+    # Try partial match (label contained in response or vice versa)
+    for idx, (label, _, _) in enumerate(candidate_frames):
+        if label in best_frame_label or best_frame_label in label:
+            return idx
+
+    return None
 
 
 async def _create_event(
@@ -708,11 +746,25 @@ def setup(hass, config):
             target_width=call.target_width,
             include_filename=call.include_filename,
             expose_images=call.expose_images,
+            llm_pick_keyframe=call.llm_pick_keyframe,
         )
         call.memory = Memory(hass)
         await call.memory._update_memory()
 
         response = await request.call(call)
+
+        # Handle LLM keyframe selection
+        if call.llm_pick_keyframe and call.expose_images and processor._candidate_frames:
+            best_idx = _extract_best_frame(response, processor._candidate_frames)
+            if best_idx is not None:
+                await processor.expose_keyframe_by_index(best_idx)
+            else:
+                _LOGGER.warning(
+                    "LLM did not return a valid best_frame, "
+                    "falling back to SSIM-based selection"
+                )
+                await processor.expose_keyframe_ssim_fallback()
+
         # Add processor.key_frame to response if it exists
         if processor.key_frame:
             response["key_frame"] = processor.key_frame
@@ -748,12 +800,26 @@ def setup(hass, config):
             target_width=call.target_width,
             include_filename=call.include_filename,
             expose_images=call.expose_images,
+            llm_pick_keyframe=call.llm_pick_keyframe,
         )
 
         call.memory = Memory(hass)
         await call.memory._update_memory()
 
         response = await request.call(call)
+
+        # Handle LLM keyframe selection
+        if call.llm_pick_keyframe and call.expose_images and processor._candidate_frames:
+            best_idx = _extract_best_frame(response, processor._candidate_frames)
+            if best_idx is not None:
+                await processor.expose_keyframe_by_index(best_idx)
+            else:
+                _LOGGER.warning(
+                    "LLM did not return a valid best_frame, "
+                    "falling back to SSIM-based selection"
+                )
+                await processor.expose_keyframe_ssim_fallback()
+
         # Add processor.key_frame to response if it exists
         if processor.key_frame:
             response["key_frame"] = processor.key_frame

--- a/custom_components/llmvision/__init__.py
+++ b/custom_components/llmvision/__init__.py
@@ -584,6 +584,8 @@ async def _resolve_llm_keyframe(processor, call, response):
         return
     best_idx = _extract_and_strip_best_frame(response, processor.candidate_frames)
     if best_idx is not None:
+        label = processor.candidate_frames[best_idx][0]
+        _LOGGER.info("LLM selected keyframe: %s (index %d)", label, best_idx)
         await processor.expose_keyframe_by_index(best_idx)
     else:
         _LOGGER.warning(

--- a/custom_components/llmvision/__init__.py
+++ b/custom_components/llmvision/__init__.py
@@ -527,6 +527,9 @@ class ServiceCallData:
 def _extract_best_frame(response, candidate_frames):
     """Extract best_frame label from LLM response and return matching index.
 
+    Also strips the best_frame artifact from the response so it doesn't
+    appear in the user-visible description.
+
     Returns the index into candidate_frames, or None if no valid match found.
     """
     best_frame_label = None
@@ -535,6 +538,8 @@ def _extract_best_frame(response, candidate_frames):
     structured = response.get("structured_response")
     if structured and isinstance(structured, dict):
         best_frame_label = structured.get("best_frame")
+        # Remove best_frame from structured response
+        structured.pop("best_frame", None)
 
     # Fall back to regex parsing of text response
     if not best_frame_label:
@@ -543,6 +548,13 @@ def _extract_best_frame(response, candidate_frames):
             match = re.search(r'best_frame["\s:]+([^\n"]+)', response_text)
             if match:
                 best_frame_label = match.group(1).strip().strip('"').strip("'")
+
+    # Strip best_frame text from response_text so it doesn't show in descriptions
+    if "response_text" in response:
+        response["response_text"] = re.sub(
+            r'\s*\.?\s*best_frame["\s:]+[^\n"]+', "",
+            response["response_text"],
+        ).strip()
 
     if not best_frame_label:
         return None

--- a/custom_components/llmvision/__init__.py
+++ b/custom_components/llmvision/__init__.py
@@ -524,52 +524,73 @@ class ServiceCallData:
         return self
 
 
-def _extract_best_frame(response, candidate_frames):
-    """Extract best_frame label from LLM response and return matching index.
-
-    Also strips the best_frame artifact from the response so it doesn't
-    appear in the user-visible description.
+def _match_best_frame(label, candidate_frames):
+    """Match a best_frame label against candidate_frames.
 
     Returns the index into candidate_frames, or None if no valid match found.
     """
-    best_frame_label = None
-
-    # Check structured response first
-    structured = response.get("structured_response")
-    if structured and isinstance(structured, dict):
-        best_frame_label = structured.get("best_frame")
-        # Remove best_frame from structured response
-        structured.pop("best_frame", None)
-
-    # Fall back to regex parsing of text response
-    if not best_frame_label:
-        response_text = response.get("response_text", "")
-        if response_text:
-            match = re.search(r'best_frame["\s:]+([^\n"]+)', response_text)
-            if match:
-                best_frame_label = match.group(1).strip().strip('"').strip("'")
-
-    # Strip best_frame text from response_text so it doesn't show in descriptions
-    if "response_text" in response:
-        response["response_text"] = re.sub(
-            r'\s*\.?\s*best_frame["\s:]+[^\n"]+', "",
-            response["response_text"],
-        ).strip()
-
-    if not best_frame_label:
+    if not label or not candidate_frames:
         return None
 
-    # Exact match against candidate labels
-    for idx, (label, _, _) in enumerate(candidate_frames):
-        if label == best_frame_label:
+    # Exact match
+    for idx, (candidate_label, _, _) in enumerate(candidate_frames):
+        if candidate_label == label:
             return idx
 
-    # Try partial match (label contained in response or vice versa)
-    for idx, (label, _, _) in enumerate(candidate_frames):
-        if label in best_frame_label or best_frame_label in label:
+    # Partial match (candidate contained in label or vice versa)
+    for idx, (candidate_label, _, _) in enumerate(candidate_frames):
+        if candidate_label in label or label in candidate_label:
             return idx
 
     return None
+
+
+def _extract_and_strip_best_frame(response, candidate_frames):
+    """Extract best_frame from LLM response, strip it, and return the match index.
+
+    Mutates ``response`` in place: removes ``best_frame`` from
+    ``structured_response`` and strips the ``[BEST_FRAME: …]`` tag from
+    ``response_text`` so it never leaks into user-visible descriptions.
+
+    Returns the index into candidate_frames, or None if no valid match.
+    """
+    best_frame_label = None
+
+    # 1. Structured response (clean dict pop)
+    structured = response.get("structured_response")
+    if structured and isinstance(structured, dict):
+        best_frame_label = structured.pop("best_frame", None)
+
+    # 2. Text response: look for the bracketed tag we asked the LLM to use
+    if not best_frame_label and "response_text" in response:
+        text = response["response_text"]
+        match = re.search(r'\[BEST_FRAME:\s*([^\]]+)\]', text)
+        if match:
+            best_frame_label = match.group(1).strip()
+
+    # Always strip the tag from response_text
+    if "response_text" in response:
+        response["response_text"] = re.sub(
+            r'\s*\[BEST_FRAME:\s*[^\]]+\]', "",
+            response["response_text"],
+        ).strip()
+
+    return _match_best_frame(best_frame_label, candidate_frames)
+
+
+async def _resolve_llm_keyframe(processor, call, response):
+    """After LLM response, extract its keyframe pick or fall back to SSIM."""
+    if not (call.llm_pick_keyframe and call.expose_images and processor.candidate_frames):
+        return
+    best_idx = _extract_and_strip_best_frame(response, processor.candidate_frames)
+    if best_idx is not None:
+        await processor.expose_keyframe_by_index(best_idx)
+    else:
+        _LOGGER.warning(
+            "LLM did not return a valid best_frame, "
+            "falling back to SSIM-based selection"
+        )
+        await processor.select_and_expose_keyframe()
 
 
 async def _create_event(
@@ -724,7 +745,6 @@ def setup(hass, config):
         # Validate configuration, input data and make the call
         response = await request.call(call)
         _LOGGER.info(f"Response: {response}")
-        # Add processor.key_frame to response if it exists
         if processor.key_frame:
             _LOGGER.info(f"Key frame: {processor.key_frame}")
             response["key_frame"] = processor.key_frame
@@ -758,26 +778,17 @@ def setup(hass, config):
             target_width=call.target_width,
             include_filename=call.include_filename,
             expose_images=call.expose_images,
-            llm_pick_keyframe=call.llm_pick_keyframe,
         )
+
+        if call.expose_images and not call.llm_pick_keyframe:
+            await processor.select_and_expose_keyframe()
+
         call.memory = Memory(hass)
         await call.memory._update_memory()
 
         response = await request.call(call)
+        await _resolve_llm_keyframe(processor, call, response)
 
-        # Handle LLM keyframe selection
-        if call.llm_pick_keyframe and call.expose_images and processor._candidate_frames:
-            best_idx = _extract_best_frame(response, processor._candidate_frames)
-            if best_idx is not None:
-                await processor.expose_keyframe_by_index(best_idx)
-            else:
-                _LOGGER.warning(
-                    "LLM did not return a valid best_frame, "
-                    "falling back to SSIM-based selection"
-                )
-                await processor.expose_keyframe_ssim_fallback()
-
-        # Add processor.key_frame to response if it exists
         if processor.key_frame:
             response["key_frame"] = processor.key_frame
 
@@ -812,27 +823,17 @@ def setup(hass, config):
             target_width=call.target_width,
             include_filename=call.include_filename,
             expose_images=call.expose_images,
-            llm_pick_keyframe=call.llm_pick_keyframe,
         )
+
+        if call.expose_images and not call.llm_pick_keyframe:
+            await processor.select_and_expose_keyframe()
 
         call.memory = Memory(hass)
         await call.memory._update_memory()
 
         response = await request.call(call)
+        await _resolve_llm_keyframe(processor, call, response)
 
-        # Handle LLM keyframe selection
-        if call.llm_pick_keyframe and call.expose_images and processor._candidate_frames:
-            best_idx = _extract_best_frame(response, processor._candidate_frames)
-            if best_idx is not None:
-                await processor.expose_keyframe_by_index(best_idx)
-            else:
-                _LOGGER.warning(
-                    "LLM did not return a valid best_frame, "
-                    "falling back to SSIM-based selection"
-                )
-                await processor.expose_keyframe_ssim_fallback()
-
-        # Add processor.key_frame to response if it exists
         if processor.key_frame:
             response["key_frame"] = processor.key_frame
 
@@ -911,7 +912,6 @@ def setup(hass, config):
         await call.memory._update_memory()
 
         response = await request.call(call)
-        # Add processor.key_frame to response if it exists
         if processor.key_frame:
             response["key_frame"] = processor.key_frame
 

--- a/custom_components/llmvision/const.py
+++ b/custom_components/llmvision/const.py
@@ -73,6 +73,7 @@ INCLUDE_FILENAME = "include_filename"
 EXPOSE_IMAGES = "expose_images"
 GENERATE_TITLE = "generate_title"
 SENSOR_ENTITY = "sensor_entity"
+LLM_PICK_KEYFRAME = "llm_pick_keyframe"
 
 # Error messages
 ERROR_NOT_CONFIGURED = "{provider} is not configured"

--- a/custom_components/llmvision/media_handlers.py
+++ b/custom_components/llmvision/media_handlers.py
@@ -36,6 +36,7 @@ class MediaProcessor:
         self.filenames = []
         self.snapshots_path = f"/media/{DOMAIN}/snapshots/"
         self.key_frame = ""
+        self._candidate_frames = []  # [(label, base64_data, expose_name)]
 
     async def _encode_image(self, img):
         """Encode image as base64"""
@@ -91,6 +92,28 @@ class MediaProcessor:
                     await self.hass.loop.run_in_executor(None, image.load)
                     image_data = await self._encode_image(image)
             await self._save_clip(image_data=image_data, image_path=filename)
+
+    async def expose_keyframe_by_index(self, idx):
+        """Save a specific candidate frame as the key_frame."""
+        label, b64_data, expose_name = self._candidate_frames[idx]
+        await self._expose_image(
+            frame_name=expose_name,
+            image_data=b64_data,
+            uid=str(uuid.uuid4())[:8],
+        )
+
+    async def expose_keyframe_ssim_fallback(self):
+        """Fall back to SSIM-based selection on stashed candidates."""
+        if not self._candidate_frames:
+            return
+        candidate_bytes = [
+            base64.b64decode(b64) for _, b64, _ in self._candidate_frames
+        ]
+        reference_bytes = candidate_bytes[-1]
+        key_idx = await self._select_keyframe_index(
+            reference_bytes, candidate_bytes
+        )
+        await self.expose_keyframe_by_index(key_idx)
 
     def _similarity_score(self, previous_frame, current_frame_gray):
         """
@@ -272,6 +295,7 @@ class MediaProcessor:
         target_width,
         include_filename,
         expose_images,
+        llm_pick_keyframe=False,
     ):
         """Wrapper for client.add_frame with integrated recorder
 
@@ -491,13 +515,22 @@ class MediaProcessor:
                 self.client.add_frame(base64_image=resized_image, filename=frame_name)
 
             if expose_images:
-                key_name = selected_frames[key_idx][0]
-                key_b64 = resized_base64[key_idx]
-                await self._expose_image(
-                    frame_name=key_name.split("-")[0],
-                    image_data=key_b64,
-                    uid=str(uuid.uuid4())[:8],
-                )
+                if llm_pick_keyframe:
+                    # Stash candidates for LLM to choose later
+                    self._candidate_frames = [
+                        (fname, rb64, fname.split("-")[0])
+                        for (fname, _, _), rb64 in zip(
+                            selected_frames, resized_base64
+                        )
+                    ]
+                else:
+                    key_name = selected_frames[key_idx][0]
+                    key_b64 = resized_base64[key_idx]
+                    await self._expose_image(
+                        frame_name=key_name.split("-")[0],
+                        image_data=key_b64,
+                        uid=str(uuid.uuid4())[:8],
+                    )
 
     async def add_images(
         self, image_entities, image_paths, target_width, include_filename, expose_images
@@ -608,6 +641,7 @@ class MediaProcessor:
         target_width=640,
         include_filename=False,
         expose_images=False,
+        llm_pick_keyframe=False,
     ):
         try:
             current_event_id = str(uuid.uuid4())
@@ -890,19 +924,34 @@ class MediaProcessor:
                 )
 
             if expose_images and selected_frames:
-                # Expose keyframe if requested
-                reference_bytes = selected_frames[0][0]
-                candidate_bytes = [fd for (fd, _, _) in selected_frames]
-                key_idx = await self._select_keyframe_index(
-                    reference_bytes, candidate_bytes
-                )
-                # selected_frames items are (frame_bytes, score, original_index)
-                frame_idx_label = (selected_frames[key_idx][2] or 0) + 1
-                await self._expose_image(
-                    frame_name=str(frame_idx_label),
-                    image_data=resized_base64[key_idx],
-                    uid=str(uuid.uuid4())[:8],
-                )
+                if llm_pick_keyframe:
+                    # Stash candidates for LLM to choose later
+                    for idx_enum, (_, _, orig_idx) in enumerate(
+                        selected_frames
+                    ):
+                        label = (
+                            f"{os.path.splitext(os.path.basename(video_path))[0]} (frame {idx_enum + 1})"
+                            if include_filename
+                            else f"Video frame {idx_enum + 1}"
+                        )
+                        expose_name = str((orig_idx or 0) + 1)
+                        self._candidate_frames.append(
+                            (label, resized_base64[idx_enum], expose_name)
+                        )
+                else:
+                    # Expose keyframe if requested
+                    reference_bytes = selected_frames[0][0]
+                    candidate_bytes = [fd for (fd, _, _) in selected_frames]
+                    key_idx = await self._select_keyframe_index(
+                        reference_bytes, candidate_bytes
+                    )
+                    # selected_frames items are (frame_bytes, score, original_index)
+                    frame_idx_label = (selected_frames[key_idx][2] or 0) + 1
+                    await self._expose_image(
+                        frame_name=str(frame_idx_label),
+                        image_data=resized_base64[key_idx],
+                        uid=str(uuid.uuid4())[:8],
+                    )
         except Exception as e:
             raise ServiceValidationError(f"Error processing video {video_path}: {e}")
 
@@ -914,6 +963,7 @@ class MediaProcessor:
         target_width,
         include_filename,
         expose_images,
+        llm_pick_keyframe=False,
     ):
         """Wrapper for client.add_frame for videos"""
 
@@ -938,6 +988,7 @@ class MediaProcessor:
                 target_width=target_width,
                 include_filename=include_filename,
                 expose_images=expose_images,
+                llm_pick_keyframe=llm_pick_keyframe,
             )
 
         # Process videos in parallel
@@ -953,6 +1004,7 @@ class MediaProcessor:
         target_width,
         include_filename,
         expose_images,
+        llm_pick_keyframe=False,
     ):
         if image_entities:
             await self.record(
@@ -962,6 +1014,7 @@ class MediaProcessor:
                 target_width=target_width,
                 include_filename=include_filename,
                 expose_images=expose_images,
+                llm_pick_keyframe=llm_pick_keyframe,
             )
         return self.client
 

--- a/custom_components/llmvision/media_handlers.py
+++ b/custom_components/llmvision/media_handlers.py
@@ -36,7 +36,7 @@ class MediaProcessor:
         self.filenames = []
         self.snapshots_path = f"/media/{DOMAIN}/snapshots/"
         self.key_frame = ""
-        self._candidate_frames = []  # [(label, base64_data, expose_name)]
+        self.candidate_frames = []  # [(label, base64_data, expose_name)]
 
     async def _encode_image(self, img):
         """Encode image as base64"""
@@ -95,19 +95,19 @@ class MediaProcessor:
 
     async def expose_keyframe_by_index(self, idx):
         """Save a specific candidate frame as the key_frame."""
-        label, b64_data, expose_name = self._candidate_frames[idx]
+        label, b64_data, expose_name = self.candidate_frames[idx]
         await self._expose_image(
             frame_name=expose_name,
             image_data=b64_data,
             uid=str(uuid.uuid4())[:8],
         )
 
-    async def expose_keyframe_ssim_fallback(self):
-        """Fall back to SSIM-based selection on stashed candidates."""
-        if not self._candidate_frames:
+    async def select_and_expose_keyframe(self):
+        """Select keyframe via SSIM from stashed candidates and expose it."""
+        if not self.candidate_frames:
             return
         candidate_bytes = [
-            base64.b64decode(b64) for _, b64, _ in self._candidate_frames
+            base64.b64decode(b64) for _, b64, _ in self.candidate_frames
         ]
         reference_bytes = candidate_bytes[-1]
         key_idx = await self._select_keyframe_index(
@@ -295,7 +295,6 @@ class MediaProcessor:
         target_width,
         include_filename,
         expose_images,
-        llm_pick_keyframe=False,
     ):
         """Wrapper for client.add_frame with integrated recorder
 
@@ -498,14 +497,6 @@ class MediaProcessor:
 
         # Add selected frames to client
         if selected_frames:
-            # Choose keyframe among the selected frames using the last as reference
-            reference_bytes = selected_frames[-1][1]
-            candidate_bytes = [data for _, data, _ in selected_frames]
-            key_idx = await self._select_keyframe_index(
-                reference_bytes, candidate_bytes
-            )
-
-            # Add all frames (resized) and expose only the chosen keyframe
             resized_base64 = []
             for frame_name, frame_data, _ in selected_frames:
                 resized_image = await self.resize_image(
@@ -515,22 +506,12 @@ class MediaProcessor:
                 self.client.add_frame(base64_image=resized_image, filename=frame_name)
 
             if expose_images:
-                if llm_pick_keyframe:
-                    # Stash candidates for LLM to choose later
-                    self._candidate_frames = [
-                        (fname, rb64, fname.split("-")[0])
-                        for (fname, _, _), rb64 in zip(
-                            selected_frames, resized_base64
-                        )
-                    ]
-                else:
-                    key_name = selected_frames[key_idx][0]
-                    key_b64 = resized_base64[key_idx]
-                    await self._expose_image(
-                        frame_name=key_name.split("-")[0],
-                        image_data=key_b64,
-                        uid=str(uuid.uuid4())[:8],
+                self.candidate_frames = [
+                    (fname, rb64, fname.split("-")[0])
+                    for (fname, _, _), rb64 in zip(
+                        selected_frames, resized_base64
                     )
+                ]
 
     async def add_images(
         self, image_entities, image_paths, target_width, include_filename, expose_images
@@ -641,7 +622,6 @@ class MediaProcessor:
         target_width=640,
         include_filename=False,
         expose_images=False,
-        llm_pick_keyframe=False,
     ):
         try:
             current_event_id = str(uuid.uuid4())
@@ -924,33 +904,17 @@ class MediaProcessor:
                 )
 
             if expose_images and selected_frames:
-                if llm_pick_keyframe:
-                    # Stash candidates for LLM to choose later
-                    for idx_enum, (_, _, orig_idx) in enumerate(
-                        selected_frames
-                    ):
-                        label = (
-                            f"{os.path.splitext(os.path.basename(video_path))[0]} (frame {idx_enum + 1})"
-                            if include_filename
-                            else f"Video frame {idx_enum + 1}"
-                        )
-                        expose_name = str((orig_idx or 0) + 1)
-                        self._candidate_frames.append(
-                            (label, resized_base64[idx_enum], expose_name)
-                        )
-                else:
-                    # Expose keyframe if requested
-                    reference_bytes = selected_frames[0][0]
-                    candidate_bytes = [fd for (fd, _, _) in selected_frames]
-                    key_idx = await self._select_keyframe_index(
-                        reference_bytes, candidate_bytes
+                for idx_enum, (_, _, orig_idx) in enumerate(
+                    selected_frames
+                ):
+                    label = (
+                        f"{os.path.splitext(os.path.basename(video_path))[0]} (frame {idx_enum + 1})"
+                        if include_filename
+                        else f"Video frame {idx_enum + 1}"
                     )
-                    # selected_frames items are (frame_bytes, score, original_index)
-                    frame_idx_label = (selected_frames[key_idx][2] or 0) + 1
-                    await self._expose_image(
-                        frame_name=str(frame_idx_label),
-                        image_data=resized_base64[key_idx],
-                        uid=str(uuid.uuid4())[:8],
+                    expose_name = str((orig_idx or 0) + 1)
+                    self.candidate_frames.append(
+                        (label, resized_base64[idx_enum], expose_name)
                     )
         except Exception as e:
             raise ServiceValidationError(f"Error processing video {video_path}: {e}")
@@ -963,7 +927,6 @@ class MediaProcessor:
         target_width,
         include_filename,
         expose_images,
-        llm_pick_keyframe=False,
     ):
         """Wrapper for client.add_frame for videos"""
 
@@ -980,19 +943,18 @@ class MediaProcessor:
 
         _LOGGER.debug(f"Processing videos: {video_paths}")
 
-        def process_video(video_path):
-            return self.add_video(
+        # Process videos sequentially to avoid concurrent appends to
+        # candidate_frames (asyncio.gather on coroutines sharing mutable
+        # state is a race condition).
+        for video_path in video_paths:
+            await self.add_video(
                 video_path=video_path,
                 base_url=base_url,
                 max_frames=max_frames,
                 target_width=target_width,
                 include_filename=include_filename,
                 expose_images=expose_images,
-                llm_pick_keyframe=llm_pick_keyframe,
             )
-
-        # Process videos in parallel
-        await asyncio.gather(*map(process_video, video_paths))
 
         return self.client
 
@@ -1004,7 +966,6 @@ class MediaProcessor:
         target_width,
         include_filename,
         expose_images,
-        llm_pick_keyframe=False,
     ):
         if image_entities:
             await self.record(
@@ -1014,7 +975,6 @@ class MediaProcessor:
                 target_width=target_width,
                 include_filename=include_filename,
                 expose_images=expose_images,
-                llm_pick_keyframe=llm_pick_keyframe,
             )
         return self.client
 

--- a/custom_components/llmvision/providers.py
+++ b/custom_components/llmvision/providers.py
@@ -169,6 +169,32 @@ class Request:
         call.base64_images = self.base64_images
         call.filenames = self.filenames
 
+        # Inject best_frame instruction when llm_pick_keyframe is enabled
+        if getattr(call, 'llm_pick_keyframe', False) and getattr(call, 'expose_images', False):
+            call.message += (
+                "\n\nIMPORTANT: Each image above is labeled with a frame identifier "
+                "(shown before each image). After your analysis, you MUST also specify "
+                "which single frame best represents the event described above. "
+                'Return your choice as a "best_frame" field containing the exact frame label. '
+                "Choose the frame where the subject or activity is most clearly visible "
+                "and identifiable — prefer a frame that shows the key subject (person, "
+                "animal, package, etc.) rather than an empty scene."
+            )
+            # Inject best_frame into JSON schema if structured output is used
+            if getattr(call, 'response_format', 'text') == "json" and getattr(call, 'structure', None):
+                try:
+                    schema = json.loads(call.structure) if isinstance(call.structure, str) else call.structure
+                    if "properties" in schema:
+                        schema["properties"]["best_frame"] = {
+                            "type": "string",
+                            "description": "The exact frame label of the frame that best shows the primary subject"
+                        }
+                        if "required" in schema and isinstance(schema["required"], list):
+                            schema["required"].append("best_frame")
+                        call.structure = json.dumps(schema)
+                except (json.JSONDecodeError, TypeError, KeyError):
+                    pass  # Skip schema injection on error, text parsing will handle it
+
         self.validate(call)
 
         # Get fallback provider from settings

--- a/custom_components/llmvision/providers.py
+++ b/custom_components/llmvision/providers.py
@@ -169,19 +169,24 @@ class Request:
         call.base64_images = self.base64_images
         call.filenames = self.filenames
 
-        # Inject best_frame instruction when llm_pick_keyframe is enabled
-        if getattr(call, 'llm_pick_keyframe', False) and getattr(call, 'expose_images', False):
+        # Inject best_frame instruction when llm_pick_keyframe is enabled.
+        # Guard against double-injection on fallback retry.
+        if (
+            call.llm_pick_keyframe
+            and call.expose_images
+            and "[BEST_FRAME:" not in call.message
+        ):
             call.message += (
-                "\n\nIMPORTANT: Each image above is labeled with a frame identifier "
-                "(shown before each image). After your analysis, you MUST also specify "
-                "which single frame best represents the event described above. "
-                'Return your choice as a "best_frame" field containing the exact frame label. '
-                "Choose the frame where the subject or activity is most clearly visible "
-                "and identifiable — prefer a frame that shows the key subject (person, "
-                "animal, package, etc.) rather than an empty scene."
+                "\n\nEach image is labeled with a frame identifier. "
+                "After your analysis, choose the single frame that best "
+                "represents the event — prefer a frame where the key subject "
+                "(person, animal, package, vehicle, etc.) is most clearly "
+                "visible, rather than an empty scene. "
+                "Append your choice on its own line in this exact format: "
+                "[BEST_FRAME: <frame label>]"
             )
             # Inject best_frame into JSON schema if structured output is used
-            if getattr(call, 'response_format', 'text') == "json" and getattr(call, 'structure', None):
+            if call.response_format == "json" and call.structure:
                 try:
                     schema = json.loads(call.structure) if isinstance(call.structure, str) else call.structure
                     if "properties" in schema:
@@ -193,7 +198,7 @@ class Request:
                             schema["required"].append("best_frame")
                         call.structure = json.dumps(schema)
                 except (json.JSONDecodeError, TypeError, KeyError):
-                    pass  # Skip schema injection on error, text parsing will handle it
+                    pass
 
         self.validate(call)
 

--- a/custom_components/llmvision/services.yaml
+++ b/custom_components/llmvision/services.yaml
@@ -246,6 +246,13 @@ video_analyzer:
       default: false
       selector:
         boolean:
+    llm_pick_keyframe:
+      name: LLM Pick Keyframe
+      description: Let the AI model choose which frame best represents the event for the timeline snapshot, instead of using motion-based selection. Requires 'Expose Images' to be enabled.
+      required: false
+      default: false
+      selector:
+        boolean:
     response_format:
       name: Response Format
       description: Format of the response - text for natural language or json for structured data
@@ -393,6 +400,13 @@ stream_analyzer:
       description: Save the key frame. This will save analyzed frames in /media/llmvision/snapshots so they can be used for notifications. The file path will be included in the response.
       required: false
       example: false
+      default: false
+      selector:
+        boolean:
+    llm_pick_keyframe:
+      name: LLM Pick Keyframe
+      description: Let the AI model choose which frame best represents the event for the timeline snapshot, instead of using motion-based selection. Requires 'Expose Images' to be enabled.
+      required: false
       default: false
       selector:
         boolean:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,6 +2,7 @@
 import pytest
 from unittest.mock import Mock, patch, AsyncMock
 from custom_components.llmvision import ServiceCallData
+from custom_components.llmvision.__init__ import _extract_best_frame
 from custom_components.llmvision.const import DOMAIN
 import datetime
 
@@ -223,11 +224,114 @@ class TestAsyncUnloadEntry:
     async def test_unload_entry_without_calendar(self):
         """Test unloading entry without calendar."""
         from custom_components.llmvision import async_unload_entry
-        
+
         hass = Mock()
         entry = Mock()
         entry.data = {"provider": "OpenAI"}
-        
+
         result = await async_unload_entry(hass, entry)
-        
+
         assert result is True
+
+
+class TestExtractBestFrame:
+    """Test _extract_best_frame helper function."""
+
+    def _make_candidates(self):
+        return [
+            ("camera0-frame-1", "b64data1", "camera0"),
+            ("camera0-frame-2", "b64data2", "camera0"),
+            ("camera0-frame-3", "b64data3", "camera0"),
+        ]
+
+    def test_extract_from_structured_response(self):
+        """Test best_frame extracted from structured_response dict."""
+        response = {
+            "structured_response": {
+                "description": "A person at the door",
+                "best_frame": "camera0-frame-2",
+            }
+        }
+        candidates = self._make_candidates()
+
+        result = _extract_best_frame(response, candidates)
+
+        assert result == 1
+
+    def test_extract_from_text_response(self):
+        """Test best_frame extracted from response_text via regex."""
+        response = {
+            "response_text": 'A person was seen. best_frame: "camera0-frame-3"'
+        }
+        candidates = self._make_candidates()
+
+        result = _extract_best_frame(response, candidates)
+
+        assert result == 2
+
+    def test_extract_from_text_json_format(self):
+        """Test best_frame extracted from JSON-like text response."""
+        response = {
+            "response_text": '{"description": "test", "best_frame": "camera0-frame-1"}'
+        }
+        candidates = self._make_candidates()
+
+        result = _extract_best_frame(response, candidates)
+
+        assert result == 0
+
+    def test_returns_none_on_missing_field(self):
+        """Test returns None when best_frame not in response."""
+        response = {
+            "response_text": "A person was detected at the front door."
+        }
+        candidates = self._make_candidates()
+
+        result = _extract_best_frame(response, candidates)
+
+        assert result is None
+
+    def test_returns_none_on_invalid_label(self):
+        """Test returns None when best_frame doesn't match any candidate."""
+        response = {
+            "structured_response": {
+                "best_frame": "nonexistent-frame-99",
+            }
+        }
+        candidates = self._make_candidates()
+
+        result = _extract_best_frame(response, candidates)
+
+        assert result is None
+
+    def test_partial_match(self):
+        """Test partial matching when exact match fails."""
+        response = {
+            "structured_response": {
+                "best_frame": "camera0-frame-2:",
+            }
+        }
+        candidates = self._make_candidates()
+
+        result = _extract_best_frame(response, candidates)
+
+        # "camera0-frame-2" is contained in "camera0-frame-2:"
+        assert result == 1
+
+    def test_empty_candidates(self):
+        """Test returns None with empty candidates list."""
+        response = {
+            "structured_response": {"best_frame": "camera0-frame-1"}
+        }
+
+        result = _extract_best_frame(response, [])
+
+        assert result is None
+
+    def test_empty_response(self):
+        """Test returns None with empty response dict."""
+        candidates = self._make_candidates()
+
+        result = _extract_best_frame({}, candidates)
+
+        assert result is None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -257,6 +257,9 @@ class TestExtractBestFrame:
         result = _extract_best_frame(response, candidates)
 
         assert result == 1
+        # best_frame should be stripped from structured response
+        assert "best_frame" not in response["structured_response"]
+        assert response["structured_response"]["description"] == "A person at the door"
 
     def test_extract_from_text_response(self):
         """Test best_frame extracted from response_text via regex."""
@@ -268,6 +271,9 @@ class TestExtractBestFrame:
         result = _extract_best_frame(response, candidates)
 
         assert result == 2
+        # best_frame text should be stripped from response_text
+        assert "best_frame" not in response["response_text"]
+        assert "A person was seen" in response["response_text"]
 
     def test_extract_from_text_json_format(self):
         """Test best_frame extracted from JSON-like text response."""
@@ -290,6 +296,8 @@ class TestExtractBestFrame:
         result = _extract_best_frame(response, candidates)
 
         assert result is None
+        # response_text should be unchanged when no best_frame present
+        assert response["response_text"] == "A person was detected at the front door."
 
     def test_returns_none_on_invalid_label(self):
         """Test returns None when best_frame doesn't match any candidate."""
@@ -335,3 +343,29 @@ class TestExtractBestFrame:
         result = _extract_best_frame({}, candidates)
 
         assert result is None
+
+    def test_strips_best_frame_from_text_with_unquoted_label(self):
+        """Test stripping best_frame when label is unquoted."""
+        response = {
+            "response_text": "A delivery person dropped off a package. best_frame: camera0-frame-2"
+        }
+        candidates = self._make_candidates()
+
+        result = _extract_best_frame(response, candidates)
+
+        assert result == 1
+        assert "best_frame" not in response["response_text"]
+        assert "A delivery person dropped off a package" in response["response_text"]
+
+    def test_strips_best_frame_at_end_of_sentence(self):
+        """Test stripping best_frame that follows a period."""
+        response = {
+            "response_text": 'Someone is at the front door. best_frame: "camera0-frame-1"'
+        }
+        candidates = self._make_candidates()
+
+        result = _extract_best_frame(response, candidates)
+
+        assert result == 0
+        assert "best_frame" not in response["response_text"]
+        assert "Someone is at the front door" in response["response_text"]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,7 +2,10 @@
 import pytest
 from unittest.mock import Mock, patch, AsyncMock
 from custom_components.llmvision import ServiceCallData
-from custom_components.llmvision.__init__ import _extract_best_frame
+from custom_components.llmvision.__init__ import (
+    _extract_and_strip_best_frame,
+    _match_best_frame,
+)
 from custom_components.llmvision.const import DOMAIN
 import datetime
 
@@ -234,8 +237,44 @@ class TestAsyncUnloadEntry:
         assert result is True
 
 
-class TestExtractBestFrame:
-    """Test _extract_best_frame helper function."""
+class TestMatchBestFrame:
+    """Test _match_best_frame helper function."""
+
+    def _make_candidates(self):
+        return [
+            ("camera0-frame-1", "b64data1", "camera0"),
+            ("camera0-frame-2", "b64data2", "camera0"),
+            ("camera0-frame-3", "b64data3", "camera0"),
+        ]
+
+    def test_exact_match(self):
+        """Test exact label match."""
+        assert _match_best_frame("camera0-frame-2", self._make_candidates()) == 1
+
+    def test_partial_match(self):
+        """Test partial matching when exact match fails."""
+        # "camera0-frame-2" is contained in "camera0-frame-2:"
+        assert _match_best_frame("camera0-frame-2:", self._make_candidates()) == 1
+
+    def test_no_match(self):
+        """Test returns None when label doesn't match any candidate."""
+        assert _match_best_frame("nonexistent-99", self._make_candidates()) is None
+
+    def test_empty_candidates(self):
+        """Test returns None with empty candidates list."""
+        assert _match_best_frame("camera0-frame-1", []) is None
+
+    def test_none_label(self):
+        """Test returns None with None label."""
+        assert _match_best_frame(None, self._make_candidates()) is None
+
+    def test_empty_label(self):
+        """Test returns None with empty string label."""
+        assert _match_best_frame("", self._make_candidates()) is None
+
+
+class TestExtractAndStripBestFrame:
+    """Test _extract_and_strip_best_frame function."""
 
     def _make_candidates(self):
         return [
@@ -245,7 +284,7 @@ class TestExtractBestFrame:
         ]
 
     def test_extract_from_structured_response(self):
-        """Test best_frame extracted from structured_response dict."""
+        """Test best_frame extracted and stripped from structured_response."""
         response = {
             "structured_response": {
                 "description": "A person at the door",
@@ -254,118 +293,77 @@ class TestExtractBestFrame:
         }
         candidates = self._make_candidates()
 
-        result = _extract_best_frame(response, candidates)
+        result = _extract_and_strip_best_frame(response, candidates)
 
         assert result == 1
-        # best_frame should be stripped from structured response
         assert "best_frame" not in response["structured_response"]
         assert response["structured_response"]["description"] == "A person at the door"
 
-    def test_extract_from_text_response(self):
-        """Test best_frame extracted from response_text via regex."""
+    def test_extract_from_bracketed_tag(self):
+        """Test best_frame extracted from [BEST_FRAME: ...] tag in text."""
         response = {
-            "response_text": 'A person was seen. best_frame: "camera0-frame-3"'
+            "response_text": "A person was seen.\n[BEST_FRAME: camera0-frame-3]"
         }
         candidates = self._make_candidates()
 
-        result = _extract_best_frame(response, candidates)
+        result = _extract_and_strip_best_frame(response, candidates)
 
         assert result == 2
-        # best_frame text should be stripped from response_text
-        assert "best_frame" not in response["response_text"]
-        assert "A person was seen" in response["response_text"]
+        assert "BEST_FRAME" not in response["response_text"]
+        assert "A person was seen." in response["response_text"]
 
-    def test_extract_from_text_json_format(self):
-        """Test best_frame extracted from JSON-like text response."""
+    def test_strips_tag_from_text(self):
+        """Test that the tag is removed from response_text."""
         response = {
-            "response_text": '{"description": "test", "best_frame": "camera0-frame-1"}'
+            "response_text": "Delivery at the door. [BEST_FRAME: camera0-frame-1]"
         }
         candidates = self._make_candidates()
 
-        result = _extract_best_frame(response, candidates)
+        _extract_and_strip_best_frame(response, candidates)
 
-        assert result == 0
+        assert response["response_text"] == "Delivery at the door."
 
-    def test_returns_none_on_missing_field(self):
-        """Test returns None when best_frame not in response."""
+    def test_no_tag_leaves_text_unchanged(self):
+        """Test response_text is unchanged when no tag is present."""
         response = {
             "response_text": "A person was detected at the front door."
         }
         candidates = self._make_candidates()
 
-        result = _extract_best_frame(response, candidates)
+        result = _extract_and_strip_best_frame(response, candidates)
 
         assert result is None
-        # response_text should be unchanged when no best_frame present
         assert response["response_text"] == "A person was detected at the front door."
 
     def test_returns_none_on_invalid_label(self):
-        """Test returns None when best_frame doesn't match any candidate."""
+        """Test returns None when label doesn't match any candidate."""
         response = {
-            "structured_response": {
-                "best_frame": "nonexistent-frame-99",
-            }
+            "structured_response": {"best_frame": "nonexistent-frame-99"}
         }
         candidates = self._make_candidates()
 
-        result = _extract_best_frame(response, candidates)
-
-        assert result is None
-
-    def test_partial_match(self):
-        """Test partial matching when exact match fails."""
-        response = {
-            "structured_response": {
-                "best_frame": "camera0-frame-2:",
-            }
-        }
-        candidates = self._make_candidates()
-
-        result = _extract_best_frame(response, candidates)
-
-        # "camera0-frame-2" is contained in "camera0-frame-2:"
-        assert result == 1
-
-    def test_empty_candidates(self):
-        """Test returns None with empty candidates list."""
-        response = {
-            "structured_response": {"best_frame": "camera0-frame-1"}
-        }
-
-        result = _extract_best_frame(response, [])
+        result = _extract_and_strip_best_frame(response, candidates)
 
         assert result is None
 
     def test_empty_response(self):
         """Test returns None with empty response dict."""
-        candidates = self._make_candidates()
-
-        result = _extract_best_frame({}, candidates)
-
+        result = _extract_and_strip_best_frame({}, self._make_candidates())
         assert result is None
 
-    def test_strips_best_frame_from_text_with_unquoted_label(self):
-        """Test stripping best_frame when label is unquoted."""
+    def test_structured_takes_priority_over_text(self):
+        """Test structured_response best_frame is used over text tag."""
         response = {
-            "response_text": "A delivery person dropped off a package. best_frame: camera0-frame-2"
+            "structured_response": {
+                "best_frame": "camera0-frame-1",
+            },
+            "response_text": "text [BEST_FRAME: camera0-frame-3]",
         }
         candidates = self._make_candidates()
 
-        result = _extract_best_frame(response, candidates)
+        result = _extract_and_strip_best_frame(response, candidates)
 
-        assert result == 1
-        assert "best_frame" not in response["response_text"]
-        assert "A delivery person dropped off a package" in response["response_text"]
-
-    def test_strips_best_frame_at_end_of_sentence(self):
-        """Test stripping best_frame that follows a period."""
-        response = {
-            "response_text": 'Someone is at the front door. best_frame: "camera0-frame-1"'
-        }
-        candidates = self._make_candidates()
-
-        result = _extract_best_frame(response, candidates)
-
+        # Structured wins
         assert result == 0
-        assert "best_frame" not in response["response_text"]
-        assert "Someone is at the front door" in response["response_text"]
+        # But text tag should still be stripped
+        assert "BEST_FRAME" not in response["response_text"]

--- a/tests/test_media_handlers.py
+++ b/tests/test_media_handlers.py
@@ -1,6 +1,6 @@
 """Unit tests for media_handlers.py module."""
 import pytest
-from unittest.mock import Mock, patch, AsyncMock, MagicMock
+from unittest.mock import Mock, patch, AsyncMock, MagicMock, call
 from PIL import Image
 import io
 import base64
@@ -42,6 +42,7 @@ class TestMediaProcessor:
         assert processor.base64_images == []
         assert processor.filenames == []
         assert processor.key_frame == ""
+        assert processor._candidate_frames == []
 
     @pytest.mark.asyncio
     async def test_encode_image(self, processor):
@@ -91,8 +92,63 @@ class TestMediaProcessor:
         # Create two similar images
         img1 = Image.new('L', (100, 100), color=128)
         img2 = Image.new('L', (100, 100), color=130)
-        
+
         score = processor._similarity_score(img1, img2)
-        
+
         assert isinstance(score, float)
         assert 0 <= score <= 1
+
+    @pytest.mark.asyncio
+    async def test_expose_keyframe_by_index(self, processor):
+        """Test expose_keyframe_by_index calls _expose_image with correct data."""
+        processor._candidate_frames = [
+            ("camera0-frame-1", "base64data1", "camera0"),
+            ("camera0-frame-2", "base64data2", "camera0"),
+            ("camera0-frame-3", "base64data3", "camera0"),
+        ]
+        processor._expose_image = AsyncMock()
+
+        await processor.expose_keyframe_by_index(1)
+
+        processor._expose_image.assert_called_once()
+        call_kwargs = processor._expose_image.call_args
+        assert call_kwargs[1]["frame_name"] == "camera0"
+        assert call_kwargs[1]["image_data"] == "base64data2"
+        assert "uid" in call_kwargs[1]
+
+    @pytest.mark.asyncio
+    async def test_expose_keyframe_ssim_fallback(self, processor):
+        """Test expose_keyframe_ssim_fallback runs SSIM and exposes winner."""
+        # Create small test images as base64
+        img1 = Image.new('RGB', (10, 10), color='red')
+        img2 = Image.new('RGB', (10, 10), color='blue')
+        img3 = Image.new('RGB', (10, 10), color='green')
+        buffers = []
+        for img in [img1, img2, img3]:
+            buf = io.BytesIO()
+            img.save(buf, format="JPEG")
+            buffers.append(base64.b64encode(buf.getvalue()).decode("utf-8"))
+
+        processor._candidate_frames = [
+            ("cam-frame-1", buffers[0], "cam"),
+            ("cam-frame-2", buffers[1], "cam"),
+            ("cam-frame-3", buffers[2], "cam"),
+        ]
+        processor._expose_image = AsyncMock()
+
+        await processor.expose_keyframe_ssim_fallback()
+
+        # Should have called _expose_image exactly once
+        processor._expose_image.assert_called_once()
+        call_kwargs = processor._expose_image.call_args[1]
+        assert call_kwargs["frame_name"] == "cam"
+
+    @pytest.mark.asyncio
+    async def test_expose_keyframe_ssim_fallback_empty_candidates(self, processor):
+        """Test expose_keyframe_ssim_fallback is no-op when candidates empty."""
+        processor._candidate_frames = []
+        processor._expose_image = AsyncMock()
+
+        await processor.expose_keyframe_ssim_fallback()
+
+        processor._expose_image.assert_not_called()

--- a/tests/test_media_handlers.py
+++ b/tests/test_media_handlers.py
@@ -42,16 +42,16 @@ class TestMediaProcessor:
         assert processor.base64_images == []
         assert processor.filenames == []
         assert processor.key_frame == ""
-        assert processor._candidate_frames == []
+        assert processor.candidate_frames == []
 
     @pytest.mark.asyncio
     async def test_encode_image(self, processor):
         """Test _encode_image method."""
         # Create a simple test image
         img = Image.new('RGB', (100, 100), color='red')
-        
+
         result = await processor._encode_image(img)
-        
+
         assert isinstance(result, str)
         assert len(result) > 0
         # Verify it's valid base64
@@ -60,17 +60,17 @@ class TestMediaProcessor:
     def test_convert_to_rgb_rgba(self, processor):
         """Test _convert_to_rgb with RGBA image."""
         img = Image.new('RGBA', (100, 100), color=(255, 0, 0, 128))
-        
+
         result = processor._convert_to_rgb(img)
-        
+
         assert result.mode == 'RGB'
 
     def test_convert_to_rgb_already_rgb(self, processor):
         """Test _convert_to_rgb with RGB image."""
         img = Image.new('RGB', (100, 100), color='red')
-        
+
         result = processor._convert_to_rgb(img)
-        
+
         assert result.mode == 'RGB'
 
     @pytest.mark.asyncio
@@ -78,12 +78,12 @@ class TestMediaProcessor:
         """Test resize_image with PIL Image object."""
         # Create a test image
         img = Image.new('RGB', (200, 100), color='blue')
-        
+
         result = await processor.resize_image(
             target_width=100,
             img=img
         )
-        
+
         assert isinstance(result, str)
         assert len(result) > 0
 
@@ -101,7 +101,7 @@ class TestMediaProcessor:
     @pytest.mark.asyncio
     async def test_expose_keyframe_by_index(self, processor):
         """Test expose_keyframe_by_index calls _expose_image with correct data."""
-        processor._candidate_frames = [
+        processor.candidate_frames = [
             ("camera0-frame-1", "base64data1", "camera0"),
             ("camera0-frame-2", "base64data2", "camera0"),
             ("camera0-frame-3", "base64data3", "camera0"),
@@ -117,8 +117,8 @@ class TestMediaProcessor:
         assert "uid" in call_kwargs[1]
 
     @pytest.mark.asyncio
-    async def test_expose_keyframe_ssim_fallback(self, processor):
-        """Test expose_keyframe_ssim_fallback runs SSIM and exposes winner."""
+    async def test_select_and_expose_keyframe(self, processor):
+        """Test select_and_expose_keyframe runs SSIM and exposes winner."""
         # Create small test images as base64
         img1 = Image.new('RGB', (10, 10), color='red')
         img2 = Image.new('RGB', (10, 10), color='blue')
@@ -129,14 +129,14 @@ class TestMediaProcessor:
             img.save(buf, format="JPEG")
             buffers.append(base64.b64encode(buf.getvalue()).decode("utf-8"))
 
-        processor._candidate_frames = [
+        processor.candidate_frames = [
             ("cam-frame-1", buffers[0], "cam"),
             ("cam-frame-2", buffers[1], "cam"),
             ("cam-frame-3", buffers[2], "cam"),
         ]
         processor._expose_image = AsyncMock()
 
-        await processor.expose_keyframe_ssim_fallback()
+        await processor.select_and_expose_keyframe()
 
         # Should have called _expose_image exactly once
         processor._expose_image.assert_called_once()
@@ -144,11 +144,11 @@ class TestMediaProcessor:
         assert call_kwargs["frame_name"] == "cam"
 
     @pytest.mark.asyncio
-    async def test_expose_keyframe_ssim_fallback_empty_candidates(self, processor):
-        """Test expose_keyframe_ssim_fallback is no-op when candidates empty."""
-        processor._candidate_frames = []
+    async def test_select_and_expose_keyframe_empty_candidates(self, processor):
+        """Test select_and_expose_keyframe is no-op when candidates empty."""
+        processor.candidate_frames = []
         processor._expose_image = AsyncMock()
 
-        await processor.expose_keyframe_ssim_fallback()
+        await processor.select_and_expose_keyframe()
 
         processor._expose_image.assert_not_called()

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,4 +1,5 @@
 """Unit tests for providers.py module."""
+import json
 import pytest
 from unittest.mock import Mock, patch, AsyncMock, MagicMock
 from homeassistant.exceptions import ServiceValidationError
@@ -637,7 +638,7 @@ class TestProviderFactory:
     def test_create_ollama(self, mock_hass_with_session):
         """Test ProviderFactory creates Ollama provider."""
         from custom_components.llmvision.providers import ProviderFactory
-        
+
         config = {
             "ip_address": "localhost",
             "port": 11434,
@@ -645,7 +646,7 @@ class TestProviderFactory:
             "keep_alive": "5m",
             "context_window": 2048
         }
-        
+
         with patch('custom_components.llmvision.providers.async_get_clientsession'):
             provider = ProviderFactory.create(
                 mock_hass_with_session,
@@ -653,6 +654,173 @@ class TestProviderFactory:
                 config,
                 "llama2"
             )
-            
+
             assert provider is not None
             assert provider.model == "llama2"
+
+
+class TestLlmPickKeyframeInjection:
+    """Test prompt and schema injection for llm_pick_keyframe."""
+
+    @pytest.fixture
+    def mock_hass_with_session(self):
+        """Create a mock Home Assistant instance with session."""
+        hass = Mock()
+        hass.data = {}
+        hass.config_entries = Mock()
+        hass.config_entries.async_entries = Mock(return_value=[])
+        hass.loop = Mock()
+        hass.loop.run_in_executor = AsyncMock()
+        hass.config = Mock()
+        hass.config.path = Mock(return_value="/mock/path")
+        return hass
+
+    @pytest.mark.asyncio
+    async def test_prompt_injection_when_enabled(self, mock_hass_with_session):
+        """Test that best_frame instruction is appended to message."""
+        mock_hass_with_session.data = {
+            DOMAIN: {
+                "test_provider": {
+                    "provider": "OpenAI",
+                    "api_key": "test_key",
+                    "temperature": 0.5,
+                    "top_p": 0.9,
+                }
+            }
+        }
+
+        with patch('custom_components.llmvision.providers.async_get_clientsession'):
+            request = Request(mock_hass_with_session, "Describe the scene", 1000, 0.5)
+            request.base64_images = ["img1"]
+            request.filenames = ["camera0-frame-1"]
+
+            call = Mock()
+            call.provider = "test_provider"
+            call.model = "gpt-4"
+            call.message = "Describe the scene"
+            call.llm_pick_keyframe = True
+            call.expose_images = True
+            call.response_format = "text"
+            call.structure = None
+            call.base64_images = ["img1"]
+            call.filenames = ["camera0-frame-1"]
+            call.generate_title = False
+            call.use_memory = False
+
+            # Mock the provider to capture the call
+            mock_provider = Mock()
+            mock_provider.vision_request = AsyncMock(return_value="A person at the door. best_frame: camera0-frame-1")
+            mock_provider.supports_structured_output = Mock(return_value=False)
+
+            with patch(
+                'custom_components.llmvision.providers.ProviderFactory.create',
+                return_value=mock_provider
+            ):
+                result = await request.call(call)
+
+            # Verify the message was modified
+            assert "best_frame" in call.message
+            assert "IMPORTANT" in call.message
+
+    @pytest.mark.asyncio
+    async def test_no_injection_when_disabled(self, mock_hass_with_session):
+        """Test that message is NOT modified when llm_pick_keyframe is False."""
+        mock_hass_with_session.data = {
+            DOMAIN: {
+                "test_provider": {
+                    "provider": "OpenAI",
+                    "api_key": "test_key",
+                    "temperature": 0.5,
+                    "top_p": 0.9,
+                }
+            }
+        }
+
+        with patch('custom_components.llmvision.providers.async_get_clientsession'):
+            request = Request(mock_hass_with_session, "Describe the scene", 1000, 0.5)
+            request.base64_images = ["img1"]
+            request.filenames = ["camera0-frame-1"]
+
+            call = Mock()
+            call.provider = "test_provider"
+            call.model = "gpt-4"
+            call.message = "Describe the scene"
+            call.llm_pick_keyframe = False
+            call.expose_images = True
+            call.response_format = "text"
+            call.structure = None
+            call.base64_images = ["img1"]
+            call.filenames = ["camera0-frame-1"]
+            call.generate_title = False
+            call.use_memory = False
+
+            mock_provider = Mock()
+            mock_provider.vision_request = AsyncMock(return_value="A person at the door.")
+            mock_provider.supports_structured_output = Mock(return_value=False)
+
+            with patch(
+                'custom_components.llmvision.providers.ProviderFactory.create',
+                return_value=mock_provider
+            ):
+                result = await request.call(call)
+
+            assert "best_frame" not in call.message
+
+    @pytest.mark.asyncio
+    async def test_schema_injection_with_structured_output(self, mock_hass_with_session):
+        """Test that best_frame is injected into JSON schema."""
+        mock_hass_with_session.data = {
+            DOMAIN: {
+                "test_provider": {
+                    "provider": "OpenAI",
+                    "api_key": "test_key",
+                    "temperature": 0.5,
+                    "top_p": 0.9,
+                }
+            }
+        }
+
+        original_schema = json.dumps({
+            "type": "object",
+            "properties": {
+                "description": {"type": "string"}
+            },
+            "required": ["description"],
+            "additionalProperties": False,
+        })
+
+        with patch('custom_components.llmvision.providers.async_get_clientsession'):
+            request = Request(mock_hass_with_session, "Describe the scene", 1000, 0.5)
+            request.base64_images = ["img1"]
+            request.filenames = ["camera0-frame-1"]
+
+            call = Mock()
+            call.provider = "test_provider"
+            call.model = "gpt-4"
+            call.message = "Describe the scene"
+            call.llm_pick_keyframe = True
+            call.expose_images = True
+            call.response_format = "json"
+            call.structure = original_schema
+            call.base64_images = ["img1"]
+            call.filenames = ["camera0-frame-1"]
+            call.generate_title = False
+            call.title_field = ""
+            call.use_memory = False
+
+            mock_provider = Mock()
+            mock_provider.vision_request = AsyncMock(
+                return_value='{"description": "test", "best_frame": "camera0-frame-1"}'
+            )
+            mock_provider.supports_structured_output = Mock(return_value=True)
+
+            with patch(
+                'custom_components.llmvision.providers.ProviderFactory.create',
+                return_value=mock_provider
+            ):
+                result = await request.call(call)
+
+            # Verify schema was modified
+            modified_schema = json.loads(call.structure)
+            assert "best_frame" in modified_schema["properties"]
+            assert "best_frame" in modified_schema["required"]

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -677,7 +677,7 @@ class TestLlmPickKeyframeInjection:
 
     @pytest.mark.asyncio
     async def test_prompt_injection_when_enabled(self, mock_hass_with_session):
-        """Test that best_frame instruction is appended to message."""
+        """Test that BEST_FRAME instruction is appended to message."""
         mock_hass_with_session.data = {
             DOMAIN: {
                 "test_provider": {
@@ -707,9 +707,10 @@ class TestLlmPickKeyframeInjection:
             call.generate_title = False
             call.use_memory = False
 
-            # Mock the provider to capture the call
             mock_provider = Mock()
-            mock_provider.vision_request = AsyncMock(return_value="A person at the door. best_frame: camera0-frame-1")
+            mock_provider.vision_request = AsyncMock(
+                return_value="A person at the door.\n[BEST_FRAME: camera0-frame-1]"
+            )
             mock_provider.supports_structured_output = Mock(return_value=False)
 
             with patch(
@@ -718,9 +719,7 @@ class TestLlmPickKeyframeInjection:
             ):
                 result = await request.call(call)
 
-            # Verify the message was modified
-            assert "best_frame" in call.message
-            assert "IMPORTANT" in call.message
+            assert "[BEST_FRAME:" in call.message
 
     @pytest.mark.asyncio
     async def test_no_injection_when_disabled(self, mock_hass_with_session):
@@ -764,7 +763,78 @@ class TestLlmPickKeyframeInjection:
             ):
                 result = await request.call(call)
 
-            assert "best_frame" not in call.message
+            assert "[BEST_FRAME:" not in call.message
+
+    @pytest.mark.asyncio
+    async def test_no_double_injection_on_retry(self, mock_hass_with_session):
+        """Test that prompt is not appended twice on fallback retry."""
+        mock_hass_with_session.data = {
+            DOMAIN: {
+                "test_provider": {
+                    "provider": "OpenAI",
+                    "api_key": "test_key",
+                    "temperature": 0.5,
+                    "top_p": 0.9,
+                },
+                "fallback_provider": {
+                    "provider": "Anthropic",
+                    "api_key": "test_key",
+                    "temperature": 0.5,
+                    "top_p": 0.9,
+                },
+            }
+        }
+
+        settings_entry = Mock()
+        settings_entry.data = {
+            "provider": "Settings",
+            "fallback_provider": "fallback_provider",
+        }
+        mock_hass_with_session.config_entries.async_entries = Mock(
+            return_value=[settings_entry]
+        )
+
+        with patch('custom_components.llmvision.providers.async_get_clientsession'):
+            request = Request(mock_hass_with_session, "Describe", 1000, 0.5)
+            request.base64_images = ["img1"]
+            request.filenames = ["cam-frame-1"]
+
+            call = Mock()
+            call.provider = "test_provider"
+            call.model = "gpt-4"
+            call.message = "Describe"
+            call.llm_pick_keyframe = True
+            call.expose_images = True
+            call.response_format = "text"
+            call.structure = None
+            call.base64_images = ["img1"]
+            call.filenames = ["cam-frame-1"]
+            call.generate_title = False
+            call.use_memory = False
+
+            # First provider fails, fallback succeeds
+            fail_provider = Mock()
+            fail_provider.vision_request = AsyncMock(side_effect=Exception("fail"))
+
+            ok_provider = Mock()
+            ok_provider.vision_request = AsyncMock(
+                return_value="OK\n[BEST_FRAME: cam-frame-1]"
+            )
+            ok_provider.supports_structured_output = Mock(return_value=False)
+
+            call_count = [0]
+            def create_provider(**kwargs):
+                call_count[0] += 1
+                return fail_provider if call_count[0] == 1 else ok_provider
+
+            with patch(
+                'custom_components.llmvision.providers.ProviderFactory.create',
+                side_effect=create_provider,
+            ):
+                await request.call(call)
+
+            # The tag should appear exactly once
+            assert call.message.count("[BEST_FRAME:") == 1
 
     @pytest.mark.asyncio
     async def test_schema_injection_with_structured_output(self, mock_hass_with_session):


### PR DESCRIPTION
First, thanks for building llmvision. It's become a key part of my Home Assistant setup and I really appreciate the work you've put into it.

## Why

When analyzing a stream, the current SSIM motion heuristic picks the frame with the most visual change. In practice that often lands on an empty scene right after the subject of interest has left the frame, so the snapshot that ends up exposed to Home Assistant isn't the one a human would have picked. Since the LLM is already looking at every candidate frame, it seemed worth letting it tell us which one best represents the event.

## How

This PR adds a new `llm_pick_keyframe` option for `video_analyzer` and `stream_analyzer`. When enabled alongside `expose_images`, the LLM is asked to identify the best frame and that frame is the one exposed. If the model's response is missing or invalid, it falls back to the existing SSIM behavior, so nothing regresses when the option is off or when the LLM misbehaves.

Implementation notes:

- New `LLM_PICK_KEYFRAME` constant and service parameter.
- Keyframe saving is deferred: candidate frames are stashed on `MediaProcessor` instead of immediately calling `_expose_image()`, so we can pick after the LLM has responded.
- A `best_frame` instruction is injected into the prompt and the JSON schema.
- `best_frame` is extracted from structured or text responses, with a fallback to SSIM-based selection when the value is missing or out of range.
- New `expose_keyframe_by_index()` and `expose_keyframe_ssim_fallback()` methods on `MediaProcessor`.
- A follow-up refactor decouples the media source from the keyframe strategy so the two paths are cleanly separated.
- Logging was added so users can see which keyframe the LLM chose.
- Tests cover extraction logic, prompt injection, schema injection, and the new `MediaProcessor` methods.

No behavior change when the option is not set. Happy to iterate on naming, defaults, or structure if you'd prefer a different shape. No pressure at all to take this, I'm maintaining it on a fork either way.

Thanks again for the project.