### PR TITLE
feat: add Mistral as a native provider

### DIFF
--- a/custom_components/llmvision/config_flow.py
+++ b/custom_components/llmvision/config_flow.py
@@ -15,6 +15,7 @@ from .providers import (
     LocalAI,
     Ollama,
     AWSBedrock,
+    Mistral,
 )
 from .const import (
     DOMAIN,
@@ -54,6 +55,7 @@ from .const import (
     DEFAULT_AWS_MODEL,
     DEFAULT_OPENWEBUI_MODEL,
     DEFAULT_OPENROUTER_MODEL,
+    DEFAULT_MISTRAL_MODEL,
     ENDPOINT_OPENWEBUI,
     ENDPOINT_AZURE,
     ENDPOINT_OPENROUTER,
@@ -87,6 +89,7 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             "OpenAI": self.async_step_openai,
             "OpenWebUI": self.async_step_openwebui,
             "OpenRouter": self.async_step_openrouter,
+            "Mistral": self.async_step_mistral,
         }
 
         step_method = provider_steps.get(provider)
@@ -125,6 +128,7 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                                 "OpenAI",
                                 "OpenWebUI",
                                 "OpenRouter",
+                                "Mistral",
                                 "Custom OpenAI",
                             ],
                             "mode": "dropdown",
@@ -1629,6 +1633,99 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="openrouter",
+            data_schema=data_schema,
+        )
+
+    async def async_step_mistral(self, user_input=None):
+        data_schema = vol.Schema(
+            {
+                vol.Optional("connection_section"): section(
+                    vol.Schema(
+                        {
+                            vol.Required(CONF_API_KEY): selector(
+                                {"text": {"type": "password"}}
+                            ),
+                        }
+                    ),
+                    {"collapsed": False},
+                ),
+                vol.Optional("model_section"): section(
+                    vol.Schema(
+                        {
+                            vol.Required(
+                                CONF_DEFAULT_MODEL, default=DEFAULT_MISTRAL_MODEL
+                            ): str,
+                            vol.Optional(CONF_TEMPERATURE, default=0.5): selector(
+                                {
+                                    "number": {
+                                        "min": 0,
+                                        "max": 1,
+                                        "step": 0.1,
+                                        "mode": "slider",
+                                    }
+                                }
+                            ),
+                            vol.Optional(CONF_TOP_P, default=0.9): selector(
+                                {
+                                    "number": {
+                                        "min": 0,
+                                        "max": 1,
+                                        "step": 0.1,
+                                        "mode": "slider",
+                                    }
+                                }
+                            ),
+                        }
+                    ),
+                    {"collapsed": False},
+                ),
+            }
+        )
+
+        if self.source == config_entries.SOURCE_RECONFIGURE:
+            self.init_info = self._get_reconfigure_entry().data
+            suggested = {
+                "connection_section": {
+                    CONF_API_KEY: self.init_info.get(CONF_API_KEY),
+                },
+                "model_section": {
+                    CONF_DEFAULT_MODEL: self.init_info.get(
+                        CONF_DEFAULT_MODEL, DEFAULT_MISTRAL_MODEL
+                    ),
+                    CONF_TEMPERATURE: self.init_info.get(CONF_TEMPERATURE, 0.5),
+                    CONF_TOP_P: self.init_info.get(CONF_TOP_P, 0.9),
+                },
+            }
+            data_schema = self.add_suggested_values_to_schema(data_schema, suggested)
+
+        if user_input is not None:
+            user_input[CONF_PROVIDER] = self.init_info[CONF_PROVIDER]
+            user_input = flatten_dict(user_input)
+            try:
+                mistral = Mistral(
+                    self.hass,
+                    api_key=user_input[CONF_API_KEY],
+                    model=user_input[CONF_DEFAULT_MODEL],
+                )
+                await mistral.validate()
+                user_input[CONF_PROVIDER] = self.init_info[CONF_PROVIDER]
+                if self.source == config_entries.SOURCE_RECONFIGURE:
+                    return self.async_update_reload_and_abort(
+                        self._get_reconfigure_entry(),
+                        data_updates=user_input,
+                    )
+                else:
+                    return self.async_create_entry(title="Mistral", data=user_input)
+            except ServiceValidationError as e:
+                _LOGGER.error(f"Validation failed: {e}")
+                return self.async_show_form(
+                    step_id="mistral",
+                    data_schema=data_schema,
+                    errors={"base": "handshake_failed"},
+                )
+
+        return self.async_show_form(
+            step_id="mistral",
             data_schema=data_schema,
         )
 

--- a/custom_components/llmvision/const.py
+++ b/custom_components/llmvision/const.py
@@ -146,6 +146,7 @@ DEFAULT_CUSTOM_OPENAI_MODEL = "gpt-4o-mini"
 DEFAULT_AWS_MODEL = "us.amazon.nova-pro-v1:0"
 DEFAULT_OPENWEBUI_MODEL = "gemma3:4b"
 DEFAULT_OPENROUTER_MODEL = "google/gemma-3-4b-it:free"
+DEFAULT_MISTRAL_MODEL = "pixtral-12b-2409"
 
 DEFAULT_SUMMARY_PROMPT = "Provide a brief summary for the following titles. Focus on the key actions or changes that occurred over time and avoid unnecessary details or subjective interpretations. The summary should be concise, objective, and relevant to the content of the images. Keep the summary under 50 words and ensure it captures the main events or activities described in the descriptions. Here are the descriptions:\n "
 
@@ -159,3 +160,4 @@ ENDPOINT_OLLAMA = "{protocol}://{ip_address}:{port}/api/chat"
 ENDPOINT_OPENWEBUI = "{protocol}://{ip_address}:{port}/api/chat/completions"
 ENDPOINT_AZURE = "{base_url}openai/deployments/{deployment}/chat/completions?api-version={api_version}"
 ENDPOINT_OPENROUTER = "https://openrouter.ai/api/v1/chat/completions"
+ENDPOINT_MISTRAL = "https://api.mistral.ai/v1/chat/completions"

--- a/custom_components/llmvision/providers.py
+++ b/custom_components/llmvision/providers.py
@@ -36,6 +36,7 @@ from .const import (
     ENDPOINT_OPENWEBUI,
     ENDPOINT_GROQ,
     ENDPOINT_OPENROUTER,
+    ENDPOINT_MISTRAL,
     ERROR_NOT_CONFIGURED,
     ERROR_GROQ_MULTIPLE_IMAGES,
     ERROR_NO_IMAGE_INPUT,
@@ -50,6 +51,7 @@ from .const import (
     DEFAULT_AWS_MODEL,
     DEFAULT_OPENWEBUI_MODEL,
     DEFAULT_OPENROUTER_MODEL,
+    DEFAULT_MISTRAL_MODEL,
     CONF_KEEP_ALIVE,
     CONF_CONTEXT_WINDOW,
     CONF_TEMPERATURE,
@@ -130,6 +132,7 @@ class Request:
             "AWS": DEFAULT_AWS_MODEL,  # For backwards compatibility
             "Open WebUI": DEFAULT_OPENWEBUI_MODEL,
             "OpenRouter": DEFAULT_OPENROUTER_MODEL,
+            "Mistral": DEFAULT_MISTRAL_MODEL,
         }.get(provider_name)
 
     def validate(self, call: Any) -> None | ServiceValidationError:
@@ -789,6 +792,28 @@ class OpenAI(Provider):
             )
         else:
             raise ServiceValidationError("empty_api_key")
+
+
+class Mistral(OpenAI):
+    """Mistral (https://docs.mistral.ai/api/). OpenAI-compatible but rejects
+    unknown fields, so rename max_completion_tokens to max_tokens."""
+
+    def __init__(self, hass: HomeAssistant, api_key: str, model: str):
+        super().__init__(
+            hass, api_key, model, endpoint={"base_url": ENDPOINT_MISTRAL}
+        )
+
+    @staticmethod
+    def _rename_token_field(payload: dict) -> dict:
+        if "max_completion_tokens" in payload:
+            payload["max_tokens"] = payload.pop("max_completion_tokens")
+        return payload
+
+    def _prepare_vision_data(self, call: Any) -> dict:
+        return self._rename_token_field(super()._prepare_vision_data(call))
+
+    def _prepare_text_data(self, call: Any) -> dict:
+        return self._rename_token_field(super()._prepare_text_data(call))
 
 
 class AzureOpenAI(Provider):
@@ -2158,6 +2183,13 @@ class ProviderFactory:
                 api_key=cast(str, config.get(CONF_API_KEY) or ""),
                 model=model,
                 endpoint={"base_url": ENDPOINT_OPENROUTER},
+            )
+
+        if provider_name == "Mistral":
+            return Mistral(
+                hass,
+                api_key=cast(str, config.get(CONF_API_KEY) or ""),
+                model=model,
             )
 
         raise ServiceValidationError("invalid_provider")

--- a/custom_components/llmvision/strings.json
+++ b/custom_components/llmvision/strings.json
@@ -359,6 +359,36 @@
                     }
                 }
             },
+            "mistral": {
+                "title": "Configure Mistral",
+                "description": "Vision-capable models (Pixtral) hosted by Mistral AI in the EU.",
+                "sections": {
+                    "connection_section": {
+                        "name": "Connection",
+                        "description": "Mistral authentication",
+                        "data": {
+                            "api_key": "API key"
+                        },
+                        "data_description": {
+                            "api_key": "Your Mistral API key from https://console.mistral.ai/."
+                        }
+                    },
+                    "model_section": {
+                        "name": "Model",
+                        "description": "Set default model parameters",
+                        "data": {
+                            "default_model": "Default model",
+                            "temperature": "Temperature",
+                            "top_p": "Top P"
+                        },
+                        "data_description": {
+                            "default_model": "Default Mistral model (e.g. pixtral-12b-2409, pixtral-large-latest).",
+                            "temperature": "Controls the randomness of the output. Lower values make the output more deterministic.",
+                            "top_p": "Controls the diversity of the output. Lower values make the output more focused."
+                        }
+                    }
+                }
+            },
             "settings": {
                 "title": "Settings",
                 "description": "Configure the LLM Vision integration. This entry is required before setting up other providers. If you wish to use the default settings, just press 'Submit'.",

--- a/custom_components/llmvision/strings.json
+++ b/custom_components/llmvision/strings.json
@@ -370,7 +370,7 @@
                             "api_key": "API key"
                         },
                         "data_description": {
-                            "api_key": "Your Mistral API key from https://console.mistral.ai/."
+                            "api_key": "Your Mistral API key from the Mistral console."
                         }
                     },
                     "model_section": {

--- a/custom_components/llmvision/translations/en.json
+++ b/custom_components/llmvision/translations/en.json
@@ -359,6 +359,36 @@
                     }
                 }
             },
+            "mistral": {
+                "title": "Configure Mistral",
+                "description": "Vision-capable models (Pixtral) hosted by Mistral AI in the EU.",
+                "sections": {
+                    "connection_section": {
+                        "name": "Connection",
+                        "description": "Mistral authentication",
+                        "data": {
+                            "api_key": "API key"
+                        },
+                        "data_description": {
+                            "api_key": "Your Mistral API key from https://console.mistral.ai/."
+                        }
+                    },
+                    "model_section": {
+                        "name": "Model",
+                        "description": "Set default model parameters",
+                        "data": {
+                            "default_model": "Default model",
+                            "temperature": "Temperature",
+                            "top_p": "Top P"
+                        },
+                        "data_description": {
+                            "default_model": "Default Mistral model (e.g. pixtral-12b-2409, pixtral-large-latest).",
+                            "temperature": "Controls the randomness of the output. Lower values make the output more deterministic.",
+                            "top_p": "Controls the diversity of the output. Lower values make the output more focused."
+                        }
+                    }
+                }
+            },
             "settings": {
                 "title": "Settings",
                 "description": "Configure the LLM Vision integration. This entry is required before setting up other providers. If you wish to use the default settings, just press 'Submit'.",

--- a/custom_components/llmvision/translations/en.json
+++ b/custom_components/llmvision/translations/en.json
@@ -370,7 +370,7 @@
                             "api_key": "API key"
                         },
                         "data_description": {
-                            "api_key": "Your Mistral API key from https://console.mistral.ai/."
+                            "api_key": "Your Mistral API key from the Mistral console."
                         }
                     },
                     "model_section": {

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -17,6 +17,7 @@ from custom_components.llmvision.providers import (
     LocalAI,
     Ollama,
     AWSBedrock,
+    Mistral,
     ProviderFactory,
 )
 from custom_components.llmvision.const import (
@@ -52,6 +53,8 @@ from custom_components.llmvision.const import (
     DEFAULT_OLLAMA_MODEL,
     DEFAULT_SYSTEM_PROMPT,
     DEFAULT_TITLE_PROMPT,
+    DEFAULT_MISTRAL_MODEL,
+    ENDPOINT_MISTRAL,
 )
 
 
@@ -661,6 +664,75 @@ class TestOpenAI:
             assert result is False
 
 
+class TestMistral:
+    """Test Mistral provider class."""
+
+    def test_init_uses_mistral_endpoint(self, mock_hass):
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            mistral = Mistral(mock_hass, "test_api_key", "pixtral-12b-2409")
+
+            assert mistral.api_key == "test_api_key"
+            assert mistral.model == "pixtral-12b-2409"
+            assert mistral.endpoint["base_url"] == ENDPOINT_MISTRAL
+
+    def test_prepare_vision_data_uses_max_tokens(self, mock_hass):
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            mistral = Mistral(mock_hass, "test_api_key", "pixtral-12b-2409")
+            call = Mock()
+            call.max_tokens = 1000
+            call.base64_images = ["base64_image"]
+            call.filenames = ["test.jpg"]
+            call.message = "Describe this image"
+            call.provider = "test_provider"
+            call.response_format = "text"
+            call.use_memory = False
+            call.structure = None
+
+            mock_hass.data = {
+                DOMAIN: {
+                    "test_provider": {
+                        "provider": "Mistral",
+                        "temperature": 0.7,
+                        "top_p": 0.9,
+                    }
+                }
+            }
+
+            with patch.object(
+                mistral, "_get_system_prompt", return_value="System prompt"
+            ):
+                result = mistral._prepare_vision_data(call)
+
+            assert result["max_tokens"] == 1000
+            assert "max_completion_tokens" not in result
+
+    def test_prepare_text_data_uses_max_tokens(self, mock_hass):
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            mistral = Mistral(mock_hass, "test_api_key", "pixtral-12b-2409")
+            call = Mock()
+            call.max_tokens = 1000
+            call.message = "Generate a title"
+            call.provider = "test_provider"
+
+            mock_hass.data = {
+                DOMAIN: {
+                    "test_provider": {
+                        "provider": "Mistral",
+                        "temperature": 0.7,
+                        "top_p": 0.9,
+                    }
+                }
+            }
+
+            with patch.object(
+                mistral, "_get_title_prompt", return_value="Title prompt"
+            ):
+                result = mistral._prepare_text_data(call)
+
+            assert result["max_tokens"] == 1000
+            assert "max_completion_tokens" not in result
+
+
 class TestAzureOpenAI:
     """Test AzureOpenAI provider class."""
 
@@ -1128,6 +1200,18 @@ class TestProviderFactory:
             )
 
             assert isinstance(provider, OpenAI)
+
+    def test_create_mistral(self, mock_hass):
+        config = {CONF_API_KEY: "test_key"}
+
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            provider = ProviderFactory.create(
+                mock_hass, "Mistral", config, "pixtral-12b-2409"
+            )
+
+            assert isinstance(provider, Mistral)
+            assert isinstance(provider, OpenAI)
+            assert provider.endpoint["base_url"] == ENDPOINT_MISTRAL
 
 
 @pytest.fixture


### PR DESCRIPTION
Mistral is OpenAI-compatible but its API rejects unknown fields. The OpenAI provider sends max_completion_tokens, which Mistral 422s on, so the Mistral class subclasses OpenAI and renames it to max_tokens. Everything else is inherited.

Default model: pixtral-12b-2409.

Closes #259

---

Supersedes #656, which was auto-closed when `v1.7.0-beta` was merged and deleted. This branch is rebased onto `main` (post-1.7.0) and addresses the review feedback from #656: the URL has been removed from the Mistral `api_key` description in `strings.json` and `translations/en.json`, since Home Assistant forbids URLs in translation strings.