### PR TITLE
fix(anthropic): only enable extended thinking when valid

### DIFF
--- a/custom_components/llmvision/providers.py
+++ b/custom_components/llmvision/providers.py
@@ -1009,6 +1009,26 @@ class Anthropic(Provider):
                 return content.get("text", "")
         return ""
 
+    def _maybe_enable_thinking(self, payload: dict, default_parameters: dict) -> None:
+        """Enable Anthropic extended thinking only when valid.
+
+        Skipped when: budget_tokens < 1024, budget not int, a non-default
+        temperature is set, or tool_choice forces tool use (structured output).
+        Mirrors the Google provider's budget>0 guard; int() coercion covers #660.
+        """
+        try:
+            budget = int(default_parameters.get('thinking_budget', 0) or 0)
+        except (TypeError, ValueError):
+            budget = 0
+        forces_tool = isinstance(payload.get('tool_choice'), dict) and (
+            payload['tool_choice'].get('type') == 'tool'
+        )
+        if budget >= 1024 and not forces_tool:
+            payload.pop('temperature', None)
+            if payload.get('max_tokens') and payload['max_tokens'] <= budget:
+                payload['max_tokens'] = budget + 1024
+            payload['thinking'] = {'type': 'enabled', 'budget_tokens': budget}
+
     def _prepare_vision_data(self, call: Any) -> dict:
         default_parameters = self._get_default_parameters(call)
         payload = {
@@ -1016,10 +1036,6 @@ class Anthropic(Provider):
             "messages": [{"role": "user", "content": []}],
             "max_tokens": call.max_tokens,
             "temperature": default_parameters.get("temperature"),
-            "thinking": {
-                "type": "enabled",
-                "budget_tokens": default_parameters.get("thinking_budget", 0),
-            },
         }
 
         # Add structured output support using tools
@@ -1049,6 +1065,9 @@ class Anthropic(Provider):
                 raise ServiceValidationError(
                     f"Invalid JSON in structure parameter: {str(e)}"
                 )
+
+        self._maybe_enable_thinking(payload, default_parameters)
+
         for image, filename in zip(call.base64_images, call.filenames):
             tag = (
                 ("Image " + str(call.base64_images.index(image) + 1))
@@ -1093,10 +1112,6 @@ class Anthropic(Provider):
             ],
             "max_tokens": call.max_tokens,
             "temperature": default_parameters.get("temperature"),
-            "thinking": {
-                "type": "enabled",
-                "budget_tokens": default_parameters.get("thinking_budget", 0),
-            },
         }
 
         # Add structured output support using tools
@@ -1127,6 +1142,7 @@ class Anthropic(Provider):
                     f"Invalid JSON in structure parameter: {str(e)}"
                 )
 
+        self._maybe_enable_thinking(payload, default_parameters)
         return payload
 
     async def validate(self) -> None | ServiceValidationError:


### PR DESCRIPTION
### Problem

v1.7.0 added an unconditional `thinking` block to every Anthropic payload in both `_prepare_vision_data` and `_prepare_text_data`:

```python
"thinking": {
    "type": "enabled",
    "budget_tokens": default_parameters.get("thinking_budget", 0),
},
```

`thinking_budget` comes from `config.get(CONF_THINKING_BUDGET, 0)`, but there's no `config_flow` field to set it — so it's always `0` while thinking is `enabled`, and the Anthropic API rejects the request. **All Anthropic requests fail in 1.7.0**; rolling back to 1.6.0 restores function.

The unconditional block violates three separate API constraints:

1. `budget_tokens` must be ≥ 1024 when thinking is enabled (default is 0)
2. thinking is incompatible with a non-default `temperature`
3. thinking is incompatible with `tool_choice` forcing tool use — which the structured-output path (`response_format=json` + `structure`) always sets

Observed: `Provider Anthropic failed: invalid_request_error: Thinking may not be enabled when tool_choice forces tool use.`

### Fix

Move the thinking decision into a `_maybe_enable_thinking()` helper called **after** the structured-output block is built (so `tool_choice` is visible). It mirrors the existing Google provider guard (#609), only enabling thinking when `budget_tokens >= 1024` **and** no tool is forced. It also coerces the budget to `int` (fixes #660) and bumps `max_tokens` above the budget.

With no budget set (the only currently reachable state) or with structured output active, thinking is skipped and the payload reverts to the working 1.6.0 shape.

### Testing

- Validated the patched payload builder against all cases: structured-output (with/without budget), plain vision (with/without budget), float budget, sub-1024 budget, None/0. All produce API-valid payloads.
- Confirmed live on HAOS with a `claude-haiku-4-5` structured-output classification script: returns valid structured JSON on the first call, no error.

### Notes

- Also present on `main` and `v1.8.0-beta` (the `providers.py` is byte-identical to v1.7.0); this patch applies cleanly to all three.
- Closes #660 (float `budget_tokens` serialization) via the `int()` coercion.
