### PR TITLE
fix: increase snapshot cleanup grace period to prevent race condition with reasoning models

### DIFF
--- a/custom_components/llmvision/timeline.py
+++ b/custom_components/llmvision/timeline.py
@@ -974,7 +974,7 @@ class Timeline:
             # Skip cleanup during migration
             return
 
-        GRACE_SECONDS = 10
+        GRACE_SECONDS = 30
 
         async with self._cleanup_lock:
             linked_frames = {


### PR DESCRIPTION
## Problem

Fixes #669

When using reasoning models like `gpt-5-mini`, the orphaned snapshot 
cleanup routine races against the API response. The cleanup fires at 
~10 seconds, but reasoning models spend tokens "thinking" before 
responding, which pushes total response time to ~10 seconds as well.

The result: the snapshot is deleted as "orphaned" before the timeline 
event is written, leaving the card with a broken image reference.

Debug log showing the race condition:

2026-06-02 13:57:25.147 INFO  Saving image to 2d442308-camera0.jpg
2026-06-02 13:57:35.191 INFO  [CLEANUP] Removing unlinked snapshot: 2d442308-camera0.jpg
2026-06-02 13:57:35.489 DEBUG Response received from gpt-5-mini (API response arrives AFTER cleanup)
2026-06-02 13:57:40.038 INFO  Creating event ... key_frame=2d442308-camera0.jpg ← file already gone

Token usage showing why reasoning models are slow:
- prompt_tokens: 6166
- completion_tokens: 472 (448 of which were reasoning_tokens)
- Total response time: ~10 seconds

## Fix

Change `GRACE_SECONDS` in `_cleanup()` from `10` to `30` in `timeline.py`.

A snapshot is only deleted if it is both unlinked AND older than 30 
seconds. This gives reasoning models sufficient time to complete their 
API call and write the timeline event before cleanup runs.

This does not affect normal models (which respond in 1-2 seconds) and 
adds no meaningful overhead to the cleanup process.