### PR TITLE
Debounce timeline calendar refresh so it stops pegging the event loop

### DIFF
--- a/custom_components/llmvision/calendar.py
+++ b/custom_components/llmvision/calendar.py
@@ -7,12 +7,18 @@ from homeassistant.components.calendar import (
 from homeassistant.components.calendar.const import CalendarEntityFeature
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.debounce import Debouncer
 from homeassistant.config_entries import ConfigEntry
 from .const import SIGNAL_TIMELINE_UPDATED
 from .timeline import Timeline
 import logging
 
 _LOGGER = logging.getLogger(__name__)
+
+# Timeline writes can arrive in rapid bursts (one per analysed camera event) and
+# every refresh reloads the full events DB. Coalesce bursts into a single reload
+# after this quiet period instead of forcing one full reload per event.
+REFRESH_COOLDOWN_SECONDS = 1.5
 
 
 class Calendar(CalendarEntity):
@@ -27,6 +33,7 @@ class Calendar(CalendarEntity):
         self._events = []
         self._current_event = None
         self._attr_supported_features = CalendarEntityFeature.DELETE_EVENT
+        self._refresh_debouncer: Debouncer | None = None
 
     @property
     def icon(self) -> str:  # type: ignore
@@ -47,17 +54,41 @@ class Calendar(CalendarEntity):
         return dt
 
     async def async_added_to_hass(self) -> None:
-        """Subscribe to timeline-updated signals so UI state refreshes after writes."""
+        """Subscribe to timeline-updated signals so UI state refreshes after writes.
+
+        Writes can arrive in rapid bursts (one per analysed camera event) and each
+        refresh reloads the whole events DB. Debounce the refresh so a burst results
+        in a single reload instead of one full reload per event, which would
+        otherwise starve the event loop.
+        """
+
+        self._refresh_debouncer = Debouncer(
+            self.hass,
+            _LOGGER,
+            cooldown=REFRESH_COOLDOWN_SECONDS,
+            immediate=False,
+            function=self._async_refresh_state,
+        )
 
         @callback
         def _handle_timeline_updated() -> None:
-            self.async_schedule_update_ha_state(force_refresh=True)
+            self.hass.async_create_task(self._refresh_debouncer.async_call())
 
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass, SIGNAL_TIMELINE_UPDATED, _handle_timeline_updated
             )
         )
+
+    async def _async_refresh_state(self) -> None:
+        """Reload events from the database and write updated state (debounced)."""
+        await self.async_update_ha_state(force_refresh=True)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Cancel any pending debounced refresh when the entity is removed."""
+        if self._refresh_debouncer is not None:
+            await self._refresh_debouncer.async_shutdown()
+
     @property
     def extra_state_attributes(self) -> dict:  # type: ignore
         """Return the state attributes"""

--- a/custom_components/llmvision/config_flow.py
+++ b/custom_components/llmvision/config_flow.py
@@ -15,6 +15,7 @@ from .providers import (
     LocalAI,
     Ollama,
     AWSBedrock,
+    Mistral,
 )
 from .const import (
     DOMAIN,
@@ -54,6 +55,7 @@ from .const import (
     DEFAULT_AWS_MODEL,
     DEFAULT_OPENWEBUI_MODEL,
     DEFAULT_OPENROUTER_MODEL,
+    DEFAULT_MISTRAL_MODEL,
     ENDPOINT_OPENWEBUI,
     ENDPOINT_AZURE,
     ENDPOINT_OPENROUTER,
@@ -87,6 +89,7 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             "OpenAI": self.async_step_openai,
             "OpenWebUI": self.async_step_openwebui,
             "OpenRouter": self.async_step_openrouter,
+            "Mistral": self.async_step_mistral,
         }
 
         step_method = provider_steps.get(provider)
@@ -125,6 +128,7 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                                 "OpenAI",
                                 "OpenWebUI",
                                 "OpenRouter",
+                                "Mistral",
                                 "Custom OpenAI",
                             ],
                             "mode": "dropdown",
@@ -1629,6 +1633,99 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="openrouter",
+            data_schema=data_schema,
+        )
+
+    async def async_step_mistral(self, user_input=None):
+        data_schema = vol.Schema(
+            {
+                vol.Optional("connection_section"): section(
+                    vol.Schema(
+                        {
+                            vol.Required(CONF_API_KEY): selector(
+                                {"text": {"type": "password"}}
+                            ),
+                        }
+                    ),
+                    {"collapsed": False},
+                ),
+                vol.Optional("model_section"): section(
+                    vol.Schema(
+                        {
+                            vol.Required(
+                                CONF_DEFAULT_MODEL, default=DEFAULT_MISTRAL_MODEL
+                            ): str,
+                            vol.Optional(CONF_TEMPERATURE, default=0.5): selector(
+                                {
+                                    "number": {
+                                        "min": 0,
+                                        "max": 1,
+                                        "step": 0.1,
+                                        "mode": "slider",
+                                    }
+                                }
+                            ),
+                            vol.Optional(CONF_TOP_P, default=0.9): selector(
+                                {
+                                    "number": {
+                                        "min": 0,
+                                        "max": 1,
+                                        "step": 0.1,
+                                        "mode": "slider",
+                                    }
+                                }
+                            ),
+                        }
+                    ),
+                    {"collapsed": False},
+                ),
+            }
+        )
+
+        if self.source == config_entries.SOURCE_RECONFIGURE:
+            self.init_info = self._get_reconfigure_entry().data
+            suggested = {
+                "connection_section": {
+                    CONF_API_KEY: self.init_info.get(CONF_API_KEY),
+                },
+                "model_section": {
+                    CONF_DEFAULT_MODEL: self.init_info.get(
+                        CONF_DEFAULT_MODEL, DEFAULT_MISTRAL_MODEL
+                    ),
+                    CONF_TEMPERATURE: self.init_info.get(CONF_TEMPERATURE, 0.5),
+                    CONF_TOP_P: self.init_info.get(CONF_TOP_P, 0.9),
+                },
+            }
+            data_schema = self.add_suggested_values_to_schema(data_schema, suggested)
+
+        if user_input is not None:
+            user_input[CONF_PROVIDER] = self.init_info[CONF_PROVIDER]
+            user_input = flatten_dict(user_input)
+            try:
+                mistral = Mistral(
+                    self.hass,
+                    api_key=user_input[CONF_API_KEY],
+                    model=user_input[CONF_DEFAULT_MODEL],
+                )
+                await mistral.validate()
+                user_input[CONF_PROVIDER] = self.init_info[CONF_PROVIDER]
+                if self.source == config_entries.SOURCE_RECONFIGURE:
+                    return self.async_update_reload_and_abort(
+                        self._get_reconfigure_entry(),
+                        data_updates=user_input,
+                    )
+                else:
+                    return self.async_create_entry(title="Mistral", data=user_input)
+            except ServiceValidationError as e:
+                _LOGGER.error(f"Validation failed: {e}")
+                return self.async_show_form(
+                    step_id="mistral",
+                    data_schema=data_schema,
+                    errors={"base": "handshake_failed"},
+                )
+
+        return self.async_show_form(
+            step_id="mistral",
             data_schema=data_schema,
         )
 

--- a/custom_components/llmvision/const.py
+++ b/custom_components/llmvision/const.py
@@ -146,6 +146,7 @@ DEFAULT_CUSTOM_OPENAI_MODEL = "gpt-4o-mini"
 DEFAULT_AWS_MODEL = "us.amazon.nova-pro-v1:0"
 DEFAULT_OPENWEBUI_MODEL = "gemma3:4b"
 DEFAULT_OPENROUTER_MODEL = "google/gemma-3-4b-it:free"
+DEFAULT_MISTRAL_MODEL = "pixtral-12b-2409"
 
 DEFAULT_SUMMARY_PROMPT = "Provide a brief summary for the following titles. Focus on the key actions or changes that occurred over time and avoid unnecessary details or subjective interpretations. The summary should be concise, objective, and relevant to the content of the images. Keep the summary under 50 words and ensure it captures the main events or activities described in the descriptions. Here are the descriptions:\n "
 
@@ -159,3 +160,4 @@ ENDPOINT_OLLAMA = "{protocol}://{ip_address}:{port}/api/chat"
 ENDPOINT_OPENWEBUI = "{protocol}://{ip_address}:{port}/api/chat/completions"
 ENDPOINT_AZURE = "{base_url}openai/deployments/{deployment}/chat/completions?api-version={api_version}"
 ENDPOINT_OPENROUTER = "https://openrouter.ai/api/v1/chat/completions"
+ENDPOINT_MISTRAL = "https://api.mistral.ai/v1/chat/completions"

--- a/custom_components/llmvision/providers.py
+++ b/custom_components/llmvision/providers.py
@@ -36,6 +36,7 @@ from .const import (
     ENDPOINT_OPENWEBUI,
     ENDPOINT_GROQ,
     ENDPOINT_OPENROUTER,
+    ENDPOINT_MISTRAL,
     ERROR_NOT_CONFIGURED,
     ERROR_GROQ_MULTIPLE_IMAGES,
     ERROR_NO_IMAGE_INPUT,
@@ -50,6 +51,7 @@ from .const import (
     DEFAULT_AWS_MODEL,
     DEFAULT_OPENWEBUI_MODEL,
     DEFAULT_OPENROUTER_MODEL,
+    DEFAULT_MISTRAL_MODEL,
     CONF_KEEP_ALIVE,
     CONF_CONTEXT_WINDOW,
     CONF_TEMPERATURE,
@@ -130,6 +132,7 @@ class Request:
             "AWS": DEFAULT_AWS_MODEL,  # For backwards compatibility
             "Open WebUI": DEFAULT_OPENWEBUI_MODEL,
             "OpenRouter": DEFAULT_OPENROUTER_MODEL,
+            "Mistral": DEFAULT_MISTRAL_MODEL,
         }.get(provider_name)
 
     def validate(self, call: Any) -> None | ServiceValidationError:
@@ -789,6 +792,28 @@ class OpenAI(Provider):
             )
         else:
             raise ServiceValidationError("empty_api_key")
+
+
+class Mistral(OpenAI):
+    """Mistral (https://docs.mistral.ai/api/). OpenAI-compatible but rejects
+    unknown fields, so rename max_completion_tokens to max_tokens."""
+
+    def __init__(self, hass: HomeAssistant, api_key: str, model: str):
+        super().__init__(
+            hass, api_key, model, endpoint={"base_url": ENDPOINT_MISTRAL}
+        )
+
+    @staticmethod
+    def _rename_token_field(payload: dict) -> dict:
+        if "max_completion_tokens" in payload:
+            payload["max_tokens"] = payload.pop("max_completion_tokens")
+        return payload
+
+    def _prepare_vision_data(self, call: Any) -> dict:
+        return self._rename_token_field(super()._prepare_vision_data(call))
+
+    def _prepare_text_data(self, call: Any) -> dict:
+        return self._rename_token_field(super()._prepare_text_data(call))
 
 
 class AzureOpenAI(Provider):
@@ -2158,6 +2183,13 @@ class ProviderFactory:
                 api_key=cast(str, config.get(CONF_API_KEY) or ""),
                 model=model,
                 endpoint={"base_url": ENDPOINT_OPENROUTER},
+            )
+
+        if provider_name == "Mistral":
+            return Mistral(
+                hass,
+                api_key=cast(str, config.get(CONF_API_KEY) or ""),
+                model=model,
             )
 
         raise ServiceValidationError("invalid_provider")

--- a/custom_components/llmvision/strings.json
+++ b/custom_components/llmvision/strings.json
@@ -359,6 +359,36 @@
                     }
                 }
             },
+            "mistral": {
+                "title": "Configure Mistral",
+                "description": "Vision-capable models (Pixtral) hosted by Mistral AI in the EU.",
+                "sections": {
+                    "connection_section": {
+                        "name": "Connection",
+                        "description": "Mistral authentication",
+                        "data": {
+                            "api_key": "API key"
+                        },
+                        "data_description": {
+                            "api_key": "Your Mistral API key from https://console.mistral.ai/."
+                        }
+                    },
+                    "model_section": {
+                        "name": "Model",
+                        "description": "Set default model parameters",
+                        "data": {
+                            "default_model": "Default model",
+                            "temperature": "Temperature",
+                            "top_p": "Top P"
+                        },
+                        "data_description": {
+                            "default_model": "Default Mistral model (e.g. pixtral-12b-2409, pixtral-large-latest).",
+                            "temperature": "Controls the randomness of the output. Lower values make the output more deterministic.",
+                            "top_p": "Controls the diversity of the output. Lower values make the output more focused."
+                        }
+                    }
+                }
+            },
             "settings": {
                 "title": "Settings",
                 "description": "Configure the LLM Vision integration. This entry is required before setting up other providers. If you wish to use the default settings, just press 'Submit'.",

--- a/custom_components/llmvision/strings.json
+++ b/custom_components/llmvision/strings.json
@@ -370,7 +370,7 @@
                             "api_key": "API key"
                         },
                         "data_description": {
-                            "api_key": "Your Mistral API key from https://console.mistral.ai/."
+                            "api_key": "Your Mistral API key from the Mistral console."
                         }
                     },
                     "model_section": {

--- a/custom_components/llmvision/timeline.py
+++ b/custom_components/llmvision/timeline.py
@@ -807,7 +807,9 @@ class Timeline:
             if pending_name:
                 self._pending_key_frames.add(pending_name)
             try:
-                await self.load_events()
+                # No pre-load needed: the in-memory list is not read before the
+                # insert below, and _insert_event() reloads it afterwards. Skipping
+                # this redundant full-DB reload keeps event creation off the hot path.
 
                 # Resolve category and label if not provided
                 if not label:

--- a/custom_components/llmvision/translations/en.json
+++ b/custom_components/llmvision/translations/en.json
@@ -359,6 +359,36 @@
                     }
                 }
             },
+            "mistral": {
+                "title": "Configure Mistral",
+                "description": "Vision-capable models (Pixtral) hosted by Mistral AI in the EU.",
+                "sections": {
+                    "connection_section": {
+                        "name": "Connection",
+                        "description": "Mistral authentication",
+                        "data": {
+                            "api_key": "API key"
+                        },
+                        "data_description": {
+                            "api_key": "Your Mistral API key from https://console.mistral.ai/."
+                        }
+                    },
+                    "model_section": {
+                        "name": "Model",
+                        "description": "Set default model parameters",
+                        "data": {
+                            "default_model": "Default model",
+                            "temperature": "Temperature",
+                            "top_p": "Top P"
+                        },
+                        "data_description": {
+                            "default_model": "Default Mistral model (e.g. pixtral-12b-2409, pixtral-large-latest).",
+                            "temperature": "Controls the randomness of the output. Lower values make the output more deterministic.",
+                            "top_p": "Controls the diversity of the output. Lower values make the output more focused."
+                        }
+                    }
+                }
+            },
             "settings": {
                 "title": "Settings",
                 "description": "Configure the LLM Vision integration. This entry is required before setting up other providers. If you wish to use the default settings, just press 'Submit'.",

--- a/custom_components/llmvision/translations/en.json
+++ b/custom_components/llmvision/translations/en.json
@@ -370,7 +370,7 @@
                             "api_key": "API key"
                         },
                         "data_description": {
-                            "api_key": "Your Mistral API key from https://console.mistral.ai/."
+                            "api_key": "Your Mistral API key from the Mistral console."
                         }
                     },
                     "model_section": {

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -219,6 +219,55 @@ class TestCalendar:
 
         mock_timeline.delete_event.assert_called_once_with(uid)
 
+    @pytest.mark.asyncio
+    async def test_timeline_updates_are_debounced(self, calendar_instance):
+        """Timeline-updated signals refresh via a debouncer, not a direct reload.
+
+        A burst of camera events (one signal each) must coalesce into a single
+        reload instead of one full DB reload per event, which would otherwise
+        saturate the event loop.
+        """
+        calendar_instance.async_on_remove = Mock()
+        with patch(
+            "custom_components.llmvision.calendar.Debouncer"
+        ) as mock_debouncer, patch(
+            "custom_components.llmvision.calendar.async_dispatcher_connect"
+        ) as mock_connect:
+            await calendar_instance.async_added_to_hass()
+
+        # A debouncer was created with the refresh coroutine and a non-zero cooldown.
+        mock_debouncer.assert_called_once()
+        _, kwargs = mock_debouncer.call_args
+        assert kwargs["function"] == calendar_instance._async_refresh_state
+        assert kwargs["cooldown"] > 0
+
+        # The signal handler routes through the debouncer instead of refreshing inline.
+        mock_connect.assert_called_once()
+        signal_handler = mock_connect.call_args[0][2]
+        signal_handler()
+        calendar_instance.hass.async_create_task.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_async_refresh_state_forces_full_reload(self, calendar_instance):
+        """The debounced refresh performs a force_refresh state update."""
+        calendar_instance.async_update_ha_state = AsyncMock()
+
+        await calendar_instance._async_refresh_state()
+
+        calendar_instance.async_update_ha_state.assert_awaited_once_with(
+            force_refresh=True
+        )
+
+    @pytest.mark.asyncio
+    async def test_pending_refresh_cancelled_on_removal(self, calendar_instance):
+        """Removing the entity shuts the debouncer down to cancel a pending refresh."""
+        debouncer = AsyncMock()
+        calendar_instance._refresh_debouncer = debouncer
+
+        await calendar_instance.async_will_remove_from_hass()
+
+        debouncer.async_shutdown.assert_awaited_once()
+
 
 class TestCalendarAdvanced:
     """Advanced tests for Calendar class."""

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -17,6 +17,7 @@ from custom_components.llmvision.providers import (
     LocalAI,
     Ollama,
     AWSBedrock,
+    Mistral,
     ProviderFactory,
 )
 from custom_components.llmvision.const import (
@@ -52,6 +53,8 @@ from custom_components.llmvision.const import (
     DEFAULT_OLLAMA_MODEL,
     DEFAULT_SYSTEM_PROMPT,
     DEFAULT_TITLE_PROMPT,
+    DEFAULT_MISTRAL_MODEL,
+    ENDPOINT_MISTRAL,
 )
 
 
@@ -661,6 +664,75 @@ class TestOpenAI:
             assert result is False
 
 
+class TestMistral:
+    """Test Mistral provider class."""
+
+    def test_init_uses_mistral_endpoint(self, mock_hass):
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            mistral = Mistral(mock_hass, "test_api_key", "pixtral-12b-2409")
+
+            assert mistral.api_key == "test_api_key"
+            assert mistral.model == "pixtral-12b-2409"
+            assert mistral.endpoint["base_url"] == ENDPOINT_MISTRAL
+
+    def test_prepare_vision_data_uses_max_tokens(self, mock_hass):
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            mistral = Mistral(mock_hass, "test_api_key", "pixtral-12b-2409")
+            call = Mock()
+            call.max_tokens = 1000
+            call.base64_images = ["base64_image"]
+            call.filenames = ["test.jpg"]
+            call.message = "Describe this image"
+            call.provider = "test_provider"
+            call.response_format = "text"
+            call.use_memory = False
+            call.structure = None
+
+            mock_hass.data = {
+                DOMAIN: {
+                    "test_provider": {
+                        "provider": "Mistral",
+                        "temperature": 0.7,
+                        "top_p": 0.9,
+                    }
+                }
+            }
+
+            with patch.object(
+                mistral, "_get_system_prompt", return_value="System prompt"
+            ):
+                result = mistral._prepare_vision_data(call)
+
+            assert result["max_tokens"] == 1000
+            assert "max_completion_tokens" not in result
+
+    def test_prepare_text_data_uses_max_tokens(self, mock_hass):
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            mistral = Mistral(mock_hass, "test_api_key", "pixtral-12b-2409")
+            call = Mock()
+            call.max_tokens = 1000
+            call.message = "Generate a title"
+            call.provider = "test_provider"
+
+            mock_hass.data = {
+                DOMAIN: {
+                    "test_provider": {
+                        "provider": "Mistral",
+                        "temperature": 0.7,
+                        "top_p": 0.9,
+                    }
+                }
+            }
+
+            with patch.object(
+                mistral, "_get_title_prompt", return_value="Title prompt"
+            ):
+                result = mistral._prepare_text_data(call)
+
+            assert result["max_tokens"] == 1000
+            assert "max_completion_tokens" not in result
+
+
 class TestAzureOpenAI:
     """Test AzureOpenAI provider class."""
 
@@ -1128,6 +1200,18 @@ class TestProviderFactory:
             )
 
             assert isinstance(provider, OpenAI)
+
+    def test_create_mistral(self, mock_hass):
+        config = {CONF_API_KEY: "test_key"}
+
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            provider = ProviderFactory.create(
+                mock_hass, "Mistral", config, "pixtral-12b-2409"
+            )
+
+            assert isinstance(provider, Mistral)
+            assert isinstance(provider, OpenAI)
+            assert provider.endpoint["base_url"] == ENDPOINT_MISTRAL
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes #673.

The timeline calendar reloads the whole events DB every time SIGNAL_TIMELINE_UPDATED fires, and that signal fires once per analysed camera event. On a busy setup this keeps the event loop busy enough that HA logs "Update of calendar.llm_vision_timeline is taking over 10 seconds" over and over, other integrations start timing out (the Frigate API in my case, even though Frigate itself answers fine), and one CPU core sits at 100%. It happens even with a small DB (about 1800 rows here), so it's the refresh frequency and the SQLite contention, not the amount of data.

I confirmed it by sampling per-thread CPU from the host: the main thread (the event loop) is the busy one, and disabling the calendar entity drops it straight back to idle.

What this PR changes:

1. calendar.py: the timeline-updated signal now goes through a Debouncer with a 1.5s cooldown, so a burst of events triggers a single reload instead of one full DB reload per event. I also added async_will_remove_from_hass to cancel a pending refresh when the entity is removed.

2. timeline.py: create_event() called await self.load_events() and then threw the result away (nothing reads self.events before the insert, and _insert_event() reloads right after), so I removed that extra full reload.

The calendar still reloads after writes, the reloads just get coalesced.

Tests:

- Full suite passes (415 passed, 4 integration tests deselected). That includes 3 new tests in tests/test_calendar.py for the debounce wiring: the signal goes through the debouncer, the debounced refresh does a force refresh, and a pending refresh is cancelled on removal.
- The existing create_event tests in tests/test_timeline.py still pass unchanged.
- Ran the patched integration on a live HA instance (2026.6.3, llmvision 1.7.0) and the slow-update warnings and the Frigate timeouts went away.

A couple of things I noticed but left out to keep this focused:

- _purge_expired_events() runs a DB query on every load_events()/get_events_json() call. Since retention is measured in days, it could be throttled.
- async_get_events() rebuilds every CalendarEvent on each call. A range-filtered query would help for large timelines.
