### PR TITLE
feat: add TwelveLabs Pegasus as a video-understanding provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 </p>
 
 ## Features
-- Supports OpenRouter, OpenAI, Anthropic, Google Gemini, AWS Bedrock, Azure, Groq, [Ollama](https://ollama.com/), [Open WebUI](https://github.com/open-webui/open-webui), [LocalAI](https://github.com/mudler/LocalAI) and any provider with OpenAI compatible endpoints.
+- Supports OpenRouter, OpenAI, Anthropic, Google Gemini, AWS Bedrock, Azure, Groq, [TwelveLabs](https://twelvelabs.io) (Pegasus video understanding), [Ollama](https://ollama.com/), [Open WebUI](https://github.com/open-webui/open-webui), [LocalAI](https://github.com/mudler/LocalAI) and any provider with OpenAI compatible endpoints.
 - Answers questions and provides descriptions of images, video files, live camera feeds, and Frigate events based on your prompt.
 - Remembers people, pets and objects
 - Keeps a timeline of camera events, so you can display them on your dashboard or ask Assist about them.

--- a/custom_components/llmvision/config_flow.py
+++ b/custom_components/llmvision/config_flow.py
@@ -16,6 +16,7 @@ from .providers import (
     Ollama,
     AWSBedrock,
     Mistral,
+    TwelveLabs,
 )
 from .const import (
     DOMAIN,
@@ -56,6 +57,7 @@ from .const import (
     DEFAULT_OPENWEBUI_MODEL,
     DEFAULT_OPENROUTER_MODEL,
     DEFAULT_MISTRAL_MODEL,
+    DEFAULT_TWELVELABS_MODEL,
     ENDPOINT_OPENWEBUI,
     ENDPOINT_AZURE,
     ENDPOINT_OPENROUTER,
@@ -90,6 +92,7 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             "OpenWebUI": self.async_step_openwebui,
             "OpenRouter": self.async_step_openrouter,
             "Mistral": self.async_step_mistral,
+            "TwelveLabs": self.async_step_twelvelabs,
         }
 
         step_method = provider_steps.get(provider)
@@ -129,6 +132,7 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                                 "OpenWebUI",
                                 "OpenRouter",
                                 "Mistral",
+                                "TwelveLabs",
                                 "Custom OpenAI",
                             ],
                             "mode": "dropdown",
@@ -1726,6 +1730,88 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="mistral",
+            data_schema=data_schema,
+        )
+
+    async def async_step_twelvelabs(self, user_input=None):
+        data_schema = vol.Schema(
+            {
+                vol.Optional("connection_section"): section(
+                    vol.Schema(
+                        {
+                            vol.Required(CONF_API_KEY): selector(
+                                {"text": {"type": "password"}}
+                            )
+                        }
+                    ),
+                    {"collapsed": False},
+                ),
+                vol.Optional("model_section"): section(
+                    vol.Schema(
+                        {
+                            vol.Required(
+                                CONF_DEFAULT_MODEL, default=DEFAULT_TWELVELABS_MODEL
+                            ): str,
+                            vol.Optional(CONF_TEMPERATURE, default=0.2): selector(
+                                {
+                                    "number": {
+                                        "min": 0,
+                                        "max": 1,
+                                        "step": 0.1,
+                                        "mode": "slider",
+                                    }
+                                }
+                            ),
+                        }
+                    ),
+                    {"collapsed": False},
+                ),
+            }
+        )
+
+        if self.source == config_entries.SOURCE_RECONFIGURE:
+            self.init_info = self._get_reconfigure_entry().data
+            suggested = {
+                "connection_section": {CONF_API_KEY: self.init_info.get(CONF_API_KEY)},
+                "model_section": {
+                    CONF_DEFAULT_MODEL: self.init_info.get(
+                        CONF_DEFAULT_MODEL, DEFAULT_TWELVELABS_MODEL
+                    ),
+                    CONF_TEMPERATURE: self.init_info.get(CONF_TEMPERATURE, 0.2),
+                },
+            }
+            data_schema = self.add_suggested_values_to_schema(data_schema, suggested)
+
+        if user_input is not None:
+            user_input[CONF_PROVIDER] = self.init_info[CONF_PROVIDER]
+            user_input = flatten_dict(user_input)
+            try:
+                twelvelabs = TwelveLabs(
+                    self.hass,
+                    api_key=user_input[CONF_API_KEY],
+                    model=user_input[CONF_DEFAULT_MODEL],
+                )
+                await twelvelabs.validate()
+                user_input[CONF_PROVIDER] = self.init_info[CONF_PROVIDER]
+                if self.source == config_entries.SOURCE_RECONFIGURE:
+                    return self.async_update_reload_and_abort(
+                        self._get_reconfigure_entry(),
+                        data_updates=user_input,
+                    )
+                else:
+                    return self.async_create_entry(
+                        title="TwelveLabs Pegasus", data=user_input
+                    )
+            except ServiceValidationError as e:
+                _LOGGER.error(f"Validation failed: {e}")
+                return self.async_show_form(
+                    step_id="twelvelabs",
+                    data_schema=data_schema,
+                    errors={"base": "empty_api_key"},
+                )
+
+        return self.async_show_form(
+            step_id="twelvelabs",
             data_schema=data_schema,
         )
 

--- a/custom_components/llmvision/const.py
+++ b/custom_components/llmvision/const.py
@@ -85,6 +85,9 @@ ERROR_NOT_CONFIGURED = "{provider} is not configured"
 ERROR_GROQ_MULTIPLE_IMAGES = "Groq does not support videos or streams"
 ERROR_NO_IMAGE_INPUT = "No image input provided"
 ERROR_HANDSHAKE_FAILED = "Connection could not be established"
+ERROR_TWELVELABS_ENCODE_FAILED = (
+    "Could not encode frames into a video clip for TwelveLabs Pegasus"
+)
 
 # Versions
 VERSION_ANTHROPIC = "2023-06-01"  # https://docs.anthropic.com/en/api/versioning
@@ -147,6 +150,7 @@ DEFAULT_AWS_MODEL = "us.amazon.nova-pro-v1:0"
 DEFAULT_OPENWEBUI_MODEL = "gemma3:4b"
 DEFAULT_OPENROUTER_MODEL = "google/gemma-3-4b-it:free"
 DEFAULT_MISTRAL_MODEL = "pixtral-12b-2409"
+DEFAULT_TWELVELABS_MODEL = "pegasus1.5"
 
 DEFAULT_SUMMARY_PROMPT = "Provide a brief summary for the following titles. Focus on the key actions or changes that occurred over time and avoid unnecessary details or subjective interpretations. The summary should be concise, objective, and relevant to the content of the images. Keep the summary under 50 words and ensure it captures the main events or activities described in the descriptions. Here are the descriptions:\n "
 
@@ -161,3 +165,4 @@ ENDPOINT_OPENWEBUI = "{protocol}://{ip_address}:{port}/api/chat/completions"
 ENDPOINT_AZURE = "{base_url}openai/deployments/{deployment}/chat/completions?api-version={api_version}"
 ENDPOINT_OPENROUTER = "https://openrouter.ai/api/v1/chat/completions"
 ENDPOINT_MISTRAL = "https://api.mistral.ai/v1/chat/completions"
+ENDPOINT_TWELVELABS = "https://api.twelvelabs.io/v1.3/analyze"

--- a/custom_components/llmvision/providers.py
+++ b/custom_components/llmvision/providers.py
@@ -11,6 +11,9 @@ import inspect
 import re
 import json
 import base64
+import asyncio
+import os
+import tempfile
 from .const import (
     DOMAIN,
     CONF_API_KEY,
@@ -37,9 +40,11 @@ from .const import (
     ENDPOINT_GROQ,
     ENDPOINT_OPENROUTER,
     ENDPOINT_MISTRAL,
+    ENDPOINT_TWELVELABS,
     ERROR_NOT_CONFIGURED,
     ERROR_GROQ_MULTIPLE_IMAGES,
     ERROR_NO_IMAGE_INPUT,
+    ERROR_TWELVELABS_ENCODE_FAILED,
     DEFAULT_OPENAI_MODEL,
     DEFAULT_ANTHROPIC_MODEL,
     DEFAULT_AZURE_MODEL,
@@ -52,6 +57,7 @@ from .const import (
     DEFAULT_OPENWEBUI_MODEL,
     DEFAULT_OPENROUTER_MODEL,
     DEFAULT_MISTRAL_MODEL,
+    DEFAULT_TWELVELABS_MODEL,
     CONF_KEEP_ALIVE,
     CONF_CONTEXT_WINDOW,
     CONF_TEMPERATURE,
@@ -133,6 +139,7 @@ class Request:
             "Open WebUI": DEFAULT_OPENWEBUI_MODEL,
             "OpenRouter": DEFAULT_OPENROUTER_MODEL,
             "Mistral": DEFAULT_MISTRAL_MODEL,
+            "TwelveLabs": DEFAULT_TWELVELABS_MODEL,
         }.get(provider_name)
 
     def validate(self, call: Any) -> None | ServiceValidationError:
@@ -2070,6 +2077,155 @@ class AWSBedrock(Provider):
         return True
 
 
+class TwelveLabs(Provider):
+    """TwelveLabs Pegasus video-understanding provider.
+
+    Unlike the other providers, Pegasus is a video model: it reasons over a
+    short clip rather than independent stills. LLM Vision always decomposes its
+    inputs (videos, camera snapshots, Frigate events) into base64 JPEG frames
+    before a provider is called, so this provider re-encodes those frames back
+    into a tiny in-memory MP4 (using the ffmpeg binary the integration already
+    requires) and sends it to the Pegasus `/analyze` endpoint. This lets
+    Pegasus pick up on motion across the keyframes instead of treating them as
+    unrelated images.
+    """
+
+    def __init__(self, hass: HomeAssistant, api_key: str, model: str):
+        super().__init__(hass, api_key, model)
+
+    def _generate_headers(self) -> dict:
+        return {"x-api-key": self.api_key, "content-type": "application/json"}
+
+    async def _frames_to_mp4_base64(self, base64_images: list, fps: int = 1) -> str:
+        """Encode an ordered list of base64 JPEG frames into a base64 MP4 clip.
+
+        Pegasus needs a real (seekable) MP4 container, so we mux through a
+        temporary file rather than a pipe. ffmpeg is already a runtime
+        requirement of this integration (see media_handlers).
+        """
+        if not base64_images:
+            raise ServiceValidationError(ERROR_NO_IMAGE_INPUT)
+
+        try:
+            jpeg_bytes = b"".join(base64.b64decode(img) for img in base64_images)
+        except Exception as e:
+            _LOGGER.error(f"Failed to decode frames for TwelveLabs: {e}")
+            raise ServiceValidationError(ERROR_TWELVELABS_ENCODE_FAILED)
+
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp:
+            output_path = tmp.name
+
+        try:
+            ffmpeg_cmd = [
+                "ffmpeg",
+                "-y",
+                "-loglevel",
+                "error",
+                "-f",
+                "image2pipe",
+                "-vcodec",
+                "mjpeg",
+                "-framerate",
+                str(fps),
+                "-i",
+                "-",
+                "-c:v",
+                "libx264",
+                "-pix_fmt",
+                "yuv420p",
+                "-movflags",
+                "+faststart",
+                output_path,
+            ]
+            process = await asyncio.create_subprocess_exec(
+                *ffmpeg_cmd,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, stderr = await process.communicate(input=jpeg_bytes)
+            if process.returncode != 0:
+                _LOGGER.error(
+                    f"ffmpeg failed to build clip for TwelveLabs: "
+                    f"{(stderr or b'').decode(errors='ignore')[:300]}"
+                )
+                raise ServiceValidationError(ERROR_TWELVELABS_ENCODE_FAILED)
+
+            with open(output_path, "rb") as f:
+                mp4_bytes = f.read()
+        finally:
+            try:
+                os.unlink(output_path)
+            except OSError:
+                pass
+
+        if not mp4_bytes:
+            raise ServiceValidationError(ERROR_TWELVELABS_ENCODE_FAILED)
+
+        return base64.b64encode(mp4_bytes).decode("utf-8")
+
+    async def _make_request(self, data: dict) -> str:
+        headers = self._generate_headers()
+        response = await self._post(url=ENDPOINT_TWELVELABS, headers=headers, data=data)
+        if not isinstance(response, dict):
+            raise ServiceValidationError("invalid_response")
+        # Pegasus may return None on an error finish_reason; surface what we can.
+        response_text = response.get("data")
+        if response_text is None:
+            raise ServiceValidationError("invalid_response")
+        return response_text.strip()
+
+    async def _prepare_vision_data(self, call: Any) -> dict:
+        # Pegasus's max_tokens has a model minimum (512); clamp to stay valid.
+        max_tokens = max(int(getattr(call, "max_tokens", 512) or 512), 512)
+        clip_base64 = await self._frames_to_mp4_base64(call.base64_images)
+        prompt = f"{self._get_system_prompt()}\n\n{call.message}"
+        return {
+            "model_name": self.model,
+            "video": {"type": "base64_string", "base64_string": clip_base64},
+            "prompt": prompt,
+            "max_tokens": max_tokens,
+            "temperature": self._get_default_parameters(call).get("temperature"),
+            "stream": False,
+        }
+
+    async def _prepare_text_data(self, call: Any) -> dict:
+        # Title generation operates on text only; Pegasus requires a video, so
+        # this path is not used (see vision_request / title_request overrides).
+        raise ServiceValidationError("invalid_provider")
+
+    async def vision_request(self, call: Any) -> str:
+        data = await self._prepare_vision_data(call)
+        return await self._make_request(data)
+
+    async def title_request(self, call: Any) -> str:
+        # Pegasus is multimodal-in/text-out only; it cannot summarise raw text.
+        # Titles are derived from the description by the orchestrator instead.
+        return "Event Detected"
+
+    async def validate(self) -> None | ServiceValidationError:
+        if not self.api_key:
+            raise ServiceValidationError("empty_api_key")
+        # Validate the key with a cheap, well-formed request. A missing video
+        # yields a 400 with a parameter error (key accepted); an invalid key
+        # yields 401. Either non-auth response confirms the key is usable.
+        headers = self._generate_headers()
+        data = {"model_name": self.model, "prompt": "Hi", "max_tokens": 512}
+        try:
+            await self._post(url=ENDPOINT_TWELVELABS, headers=headers, data=data)
+        except ServiceValidationError as e:
+            message = str(e).lower()
+            if (
+                "api" in message
+                and "key" in message
+                or "auth" in message
+                or "401" in message
+            ):
+                raise ServiceValidationError("empty_api_key")
+            # A parameter/validation error means the key authenticated fine.
+            return None
+
+
 class ProviderFactory:
     """
     Factory to create provider instances from a provider name and config
@@ -2190,6 +2346,11 @@ class ProviderFactory:
                 hass,
                 api_key=cast(str, config.get(CONF_API_KEY) or ""),
                 model=model,
+            )
+
+        if provider_name == "TwelveLabs":
+            return TwelveLabs(
+                hass, api_key=cast(str, config.get(CONF_API_KEY) or ""), model=model
             )
 
         raise ServiceValidationError("invalid_provider")

--- a/custom_components/llmvision/strings.json
+++ b/custom_components/llmvision/strings.json
@@ -389,6 +389,34 @@
                     }
                 }
             },
+            "twelvelabs": {
+                "title": "Configure TwelveLabs Pegasus",
+                "description": "Provide a valid TwelveLabs API key. Grab a free key at https://twelvelabs.io.",
+                "sections": {
+                    "connection_section": {
+                        "name": "Connection",
+                        "description": "TwelveLabs authentication",
+                        "data": {
+                            "api_key": "API key"
+                        },
+                        "data_description": {
+                            "api_key": "Your TwelveLabs API key. A generous free tier is available at https://twelvelabs.io."
+                        }
+                    },
+                    "model_section": {
+                        "name": "Model",
+                        "description": "Set default model parameters",
+                        "data": {
+                            "default_model": "Default model",
+                            "temperature": "Temperature"
+                        },
+                        "data_description": {
+                            "default_model": "The Pegasus model to use (for example pegasus1.5). Pegasus analyzes the captured frames as a short video clip.",
+                            "temperature": "Controls the randomness of the output. Lower values make the output more deterministic."
+                        }
+                    }
+                }
+            },
             "settings": {
                 "title": "Settings",
                 "description": "Configure the LLM Vision integration. This entry is required before setting up other providers. If you wish to use the default settings, just press 'Submit'.",

--- a/custom_components/llmvision/strings.json
+++ b/custom_components/llmvision/strings.json
@@ -391,7 +391,7 @@
             },
             "twelvelabs": {
                 "title": "Configure TwelveLabs Pegasus",
-                "description": "Provide a valid TwelveLabs API key. Grab a free key at https://twelvelabs.io.",
+                "description": "Provide a valid TwelveLabs API key from the TwelveLabs dashboard.",
                 "sections": {
                     "connection_section": {
                         "name": "Connection",
@@ -400,7 +400,7 @@
                             "api_key": "API key"
                         },
                         "data_description": {
-                            "api_key": "Your TwelveLabs API key. A generous free tier is available at https://twelvelabs.io."
+                            "api_key": "Your TwelveLabs API key from the TwelveLabs dashboard."
                         }
                     },
                     "model_section": {

--- a/custom_components/llmvision/translations/en.json
+++ b/custom_components/llmvision/translations/en.json
@@ -389,6 +389,34 @@
                     }
                 }
             },
+            "twelvelabs": {
+                "title": "Configure TwelveLabs Pegasus",
+                "description": "Provide a valid TwelveLabs API key. Grab a free key at https://twelvelabs.io.",
+                "sections": {
+                    "connection_section": {
+                        "name": "Connection",
+                        "description": "TwelveLabs authentication",
+                        "data": {
+                            "api_key": "API key"
+                        },
+                        "data_description": {
+                            "api_key": "Your TwelveLabs API key. A generous free tier is available at https://twelvelabs.io."
+                        }
+                    },
+                    "model_section": {
+                        "name": "Model",
+                        "description": "Set default model parameters",
+                        "data": {
+                            "default_model": "Default model",
+                            "temperature": "Temperature"
+                        },
+                        "data_description": {
+                            "default_model": "The Pegasus model to use (for example pegasus1.5). Pegasus analyzes the captured frames as a short video clip.",
+                            "temperature": "Controls the randomness of the output. Lower values make the output more deterministic."
+                        }
+                    }
+                }
+            },
             "settings": {
                 "title": "Settings",
                 "description": "Configure the LLM Vision integration. This entry is required before setting up other providers. If you wish to use the default settings, just press 'Submit'.",

--- a/custom_components/llmvision/translations/en.json
+++ b/custom_components/llmvision/translations/en.json
@@ -391,7 +391,7 @@
             },
             "twelvelabs": {
                 "title": "Configure TwelveLabs Pegasus",
-                "description": "Provide a valid TwelveLabs API key. Grab a free key at https://twelvelabs.io.",
+                "description": "Provide a valid TwelveLabs API key from the TwelveLabs dashboard.",
                 "sections": {
                     "connection_section": {
                         "name": "Connection",
@@ -400,7 +400,7 @@
                             "api_key": "API key"
                         },
                         "data_description": {
-                            "api_key": "Your TwelveLabs API key. A generous free tier is available at https://twelvelabs.io."
+                            "api_key": "Your TwelveLabs API key from the TwelveLabs dashboard."
                         }
                     },
                     "model_section": {

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,6 +1,7 @@
 """Comprehensive unit tests for providers.py module."""
 
 import json
+import os
 import pytest
 import base64
 from types import SimpleNamespace
@@ -18,6 +19,7 @@ from custom_components.llmvision.providers import (
     Ollama,
     AWSBedrock,
     Mistral,
+    TwelveLabs,
     ProviderFactory,
 )
 from custom_components.llmvision.const import (
@@ -2523,6 +2525,186 @@ async def test_provider_remaining_error_branches(coverage_hass, monkeypatch):
         return_value={"message": {"content": [{"toolUse": {"input": {"x": 1}}}]}}
     )
     assert await iam._make_request({}) == '{"x": 1}'
+
+
+class TestTwelveLabs:
+    """Test the TwelveLabs Pegasus video-understanding provider."""
+
+    def _make_provider(self, mock_hass):
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            return TwelveLabs(mock_hass, "test_api_key", "pegasus1.5")
+
+    def test_factory_creates_twelvelabs(self, mock_hass):
+        """ProviderFactory creates a TwelveLabs provider."""
+        config = {CONF_API_KEY: "test_key"}
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            provider = ProviderFactory.create(
+                mock_hass, "TwelveLabs", config, "pegasus1.5"
+            )
+        assert isinstance(provider, TwelveLabs)
+        assert provider.model == "pegasus1.5"
+
+    def test_generate_headers(self, mock_hass):
+        """Headers use the x-api-key scheme expected by the TwelveLabs API."""
+        provider = self._make_provider(mock_hass)
+        headers = provider._generate_headers()
+        assert headers["x-api-key"] == "test_api_key"
+        assert headers["content-type"] == "application/json"
+
+    async def test_frames_to_mp4_base64_empty(self, mock_hass):
+        """Encoding with no frames raises a validation error (no network/ffmpeg)."""
+        provider = self._make_provider(mock_hass)
+        with pytest.raises(ServiceValidationError):
+            await provider._frames_to_mp4_base64([])
+
+    async def test_prepare_vision_data_wiring(self, mock_hass):
+        """The analyze payload is shaped correctly without touching ffmpeg/network."""
+        provider = self._make_provider(mock_hass)
+        call = Mock()
+        call.provider = "tl_entry"
+        call.base64_images = ["frame1", "frame2"]
+        call.message = "What happened?"
+        call.max_tokens = 100  # below the model minimum -> must be clamped to 512
+        mock_hass.data = {
+            DOMAIN: {"tl_entry": {"provider": "TwelveLabs", "temperature": 0.2}}
+        }
+
+        with patch.object(
+            provider, "_frames_to_mp4_base64", AsyncMock(return_value="ZmFrZQ==")
+        ), patch.object(provider, "_get_system_prompt", return_value="System prompt"):
+            payload = await provider._prepare_vision_data(call)
+
+        assert payload["model_name"] == "pegasus1.5"
+        assert payload["video"] == {
+            "type": "base64_string",
+            "base64_string": "ZmFrZQ==",
+        }
+        assert payload["max_tokens"] == 512  # clamped up to the Pegasus minimum
+        assert payload["stream"] is False
+        assert "System prompt" in payload["prompt"]
+        assert "What happened?" in payload["prompt"]
+
+    async def test_make_request_extracts_data(self, mock_hass):
+        """_make_request returns the `data` field from the analyze response."""
+        provider = self._make_provider(mock_hass)
+        provider._post = AsyncMock(
+            return_value={
+                "id": "x",
+                "data": "A person walks by.",
+                "finish_reason": "stop",
+            }
+        )
+        assert await provider._make_request({}) == "A person walks by."
+
+    async def test_make_request_invalid_response(self, mock_hass):
+        """A response without `data` raises a validation error."""
+        provider = self._make_provider(mock_hass)
+        provider._post = AsyncMock(return_value={"id": "x", "data": None})
+        with pytest.raises(ServiceValidationError):
+            await provider._make_request({})
+
+    async def test_vision_request_end_to_end_mocked(self, mock_hass):
+        """vision_request encodes frames and posts, fully mocked (no network)."""
+        provider = self._make_provider(mock_hass)
+        call = Mock()
+        call.provider = "tl_entry"
+        call.base64_images = ["frame1"]
+        call.message = "Describe"
+        call.max_tokens = 512
+        mock_hass.data = {
+            DOMAIN: {"tl_entry": {"provider": "TwelveLabs", "temperature": 0.2}}
+        }
+
+        with patch.object(
+            provider, "_frames_to_mp4_base64", AsyncMock(return_value="ZmFrZQ==")
+        ), patch.object(
+            provider, "_get_system_prompt", return_value="sys"
+        ), patch.object(
+            provider, "_post", AsyncMock(return_value={"data": "Result."})
+        ):
+            assert await provider.vision_request(call) == "Result."
+
+    async def test_title_request_static(self, mock_hass):
+        """Pegasus is text-out only; title_request returns a static fallback."""
+        provider = self._make_provider(mock_hass)
+        assert await provider.title_request(Mock()) == "Event Detected"
+
+    async def test_validate_empty_api_key(self, mock_hass):
+        """Validation fails fast with no API key."""
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            provider = TwelveLabs(mock_hass, "", "pegasus1.5")
+        with pytest.raises(ServiceValidationError):
+            await provider.validate()
+
+    async def test_validate_parameter_error_is_accepted(self, mock_hass):
+        """A non-auth (parameter) error during validation means the key is valid."""
+        provider = self._make_provider(mock_hass)
+        provider._post = AsyncMock(
+            side_effect=ServiceValidationError(
+                "max_tokens must be between 512 and 98304"
+            )
+        )
+        # Should not raise: parameter errors confirm the key authenticated.
+        assert await provider.validate() is None
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.skipif(
+    not os.environ.get("TWELVELABS_API_KEY"),
+    reason="TWELVELABS_API_KEY not set; skipping live TwelveLabs Pegasus call",
+)
+async def test_twelvelabs_live_analyze(socket_enabled):
+    """Live smoke test against the real Pegasus /analyze endpoint.
+
+    Encodes two synthetic frames into an MP4 and asks Pegasus to describe it.
+    Requires ffmpeg on PATH and a valid TWELVELABS_API_KEY. The ``socket_enabled``
+    fixture lifts the Home Assistant test harness's default network block so this
+    opt-in test can reach the API when a key is provided.
+    """
+    import io
+    import aiohttp
+    from PIL import Image
+    from homeassistant.exceptions import ServiceValidationError as _SVE
+
+    # Build two simple JPEG frames in-memory.
+    def _jpeg(color):
+        buf = io.BytesIO()
+        Image.new("RGB", (320, 240), color).save(buf, format="JPEG")
+        return base64.b64encode(buf.getvalue()).decode()
+
+    frames = [_jpeg((20, 120, 200)), _jpeg((200, 120, 20))]
+
+    hass = Mock()
+    hass.data = {}
+    with patch(
+        "custom_components.llmvision.providers.async_get_clientsession",
+        return_value=aiohttp.ClientSession(),
+    ):
+        provider = TwelveLabs(hass, os.environ["TWELVELABS_API_KEY"], "pegasus1.5")
+    call = SimpleNamespace(
+        provider="tl",
+        base64_images=frames,
+        filenames=["a.jpg", "b.jpg"],
+        message="Describe the colors shown in this clip.",
+        max_tokens=512,
+        model_is_glimpse=lambda: False,
+    )
+    hass.data = {DOMAIN: {"tl": {"provider": "TwelveLabs", "temperature": 0.2}}}
+    with patch.object(provider, "_get_system_prompt", return_value="Be concise."):
+        try:
+            result = await provider.vision_request(call)
+        except _SVE as e:
+            # The Home Assistant test harness blocks outbound sockets by default;
+            # when running under it the call cannot reach the API. Skip rather
+            # than fail so this remains a genuine, opt-in live smoke test that
+            # passes when executed with network access (e.g. directly).
+            if "socket" in str(e).lower():
+                pytest.skip(f"network blocked by test harness: {e}")
+            raise
+        finally:
+            await provider.session.close()
+    assert isinstance(result, str) and len(result) > 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

This PR adds **TwelveLabs Pegasus** as an opt-in video-understanding provider for camera and event analysis.

### What it adds
- A new `TwelveLabs` provider that calls the Pegasus `/analyze` endpoint, wired into the `ProviderFactory`, config flow (new setup step + dropdown entry), constants, and English strings/translations — following the exact same pattern as the existing providers (it's API-key only, like Anthropic/Mistral).
- Default model `pegasus1.5`, endpoint, and error constants.
- Unit tests for the provider (no network) plus one opt-in live smoke test gated on `TWELVELABS_API_KEY`.

### Why it helps this project
Pegasus is purpose-built for *video* understanding rather than independent stills. LLM Vision already extracts keyframes from videos, camera snapshots, and Frigate events, so this provider re-encodes those frames back into a short MP4 (using the `ffmpeg` binary the integration already requires) and sends that clip to Pegasus. That lets Pegasus reason about motion across the frames — a good complement to the existing frame-by-frame VLM providers for event summaries.

### Opt-in / non-breaking
Nothing changes for existing users: no defaults are altered and no existing provider behavior is touched. Pegasus only runs if a user explicitly adds a TwelveLabs entry. No new Python dependency is introduced — the provider uses raw `aiohttp` exactly like the other HTTP providers.

### How it was tested
- `pytest tests/test_providers.py tests/test_config_flow.py` — all pass (the live test is skipped without a key).
- Verified the full path end-to-end against the real API outside the test harness: extracted JPEG frames → ffmpeg MP4 → Pegasus `/analyze` returns HTTP 200 with a correct motion-aware description. Confirmed both the `url` and `base64_string` video-context paths work, and that Pegasus enforces `max_tokens >= 512` (the provider clamps to this).
- Ran `black` on the changed files.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.

### Notes
Per CONTRIBUTING this targets the latest `v1.8.0-beta` branch. I used AI assistance for boilerplate and to verify API behavior, but I understand and stand behind every line; happy to adjust anything to fit your conventions.
