### PR TITLE
fix: key-frame cleanup race deletes snapshots mid-analysis; configurable grace + fallback-provider labels

### DIFF
--- a/blueprints/event_summary.yaml
+++ b/blueprints/event_summary.yaml
@@ -62,7 +62,9 @@ blueprint:
               reorder: false
         duration:
           name: Duration
-          description: Duration to record for analysis (in seconds).
+          description: 'Duration to record for analysis (in seconds). Longer
+            recordings take longer to analyze; if you raise this substantially,
+            also raise "Key Frame Retention Grace" below.'
           default: 5
           selector:
             number:
@@ -72,7 +74,9 @@ blueprint:
               mode: slider
         max_frames:
           name: Max Frames
-          description: How many frames to analyze. Picks frames with the most movement.
+          description: 'How many frames to analyze. Picks frames with the most
+            movement. More frames = longer analysis time; if you raise this,
+            also raise "Key Frame Retention Grace" below.'
           default: 3
           selector:
             number:
@@ -80,6 +84,26 @@ blueprint:
               max: 60.0
               step: 1.0
               mode: slider
+        keyframe_grace:
+          name: Key Frame Retention Grace
+          description: >-
+            Seconds to protect the saved key-frame snapshot from cleanup while
+            the analysis runs. Leave at 0 to use the integration global "Snapshot
+            cleanup grace" setting. Raise it whenever you increase Duration or Max
+            Frames: a longer / higher-frame-count analysis takes longer, and if
+            this grace is shorter than the analysis takes, the key frame is
+            deleted before its timeline event is saved, so the dashboard card and
+            the notification end up with no image. 0 = use the integration global
+            "Snapshot cleanup grace" setting (LLM Vision Settings > Timeline),
+            which defaults to 300 seconds (5 minutes).
+          default: 0
+          selector:
+            number:
+              min: 0.0
+              max: 3600.0
+              step: 10.0
+              unit_of_measurement: seconds
+              mode: box
     ai_section:
       name: AI Settings
       description: AI settings for the analysis.
@@ -660,6 +684,7 @@ action:
     generate_title: !input store_in_timeline
     include_filename: false
     max_frames: !input max_frames
+    keyframe_grace: !input keyframe_grace
     target_width: !input target_width
     max_tokens: !input max_tokens
   response_variable: response

--- a/blueprints/event_summary_beta.yaml
+++ b/blueprints/event_summary_beta.yaml
@@ -62,7 +62,9 @@ blueprint:
               reorder: false
         duration:
           name: Duration
-          description: Duration to record for analysis (in seconds).
+          description: 'Duration to record for analysis (in seconds). Longer
+            recordings take longer to analyze; if you raise this substantially,
+            also raise "Key Frame Retention Grace" below.'
           default: 5
           selector:
             number:
@@ -72,7 +74,9 @@ blueprint:
               mode: slider
         max_frames:
           name: Max Frames
-          description: How many frames to analyze. Picks frames with the most movement.
+          description: 'How many frames to analyze. Picks frames with the most
+            movement. More frames = longer analysis time; if you raise this,
+            also raise "Key Frame Retention Grace" below.'
           default: 3
           selector:
             number:
@@ -80,6 +84,25 @@ blueprint:
               max: 60.0
               step: 1.0
               mode: slider
+        keyframe_grace:
+          name: Key Frame Retention Grace
+          description: >-
+            Seconds to protect the saved key-frame snapshot from cleanup while
+            the analysis runs. Leave at 0 to use the integration global "Snapshot
+            cleanup grace" setting (LLM Vision Settings > Timeline), which
+            defaults to 300 seconds (5 minutes). Raise it whenever you increase
+            Duration or Max Frames: a longer / higher-frame-count analysis takes
+            longer, and if this grace is shorter than the analysis takes, the key
+            frame is deleted before its timeline event is saved, so the dashboard
+            card and the notification end up with no image.
+          default: 0
+          selector:
+            number:
+              min: 0.0
+              max: 3600.0
+              step: 10.0
+              unit_of_measurement: seconds
+              mode: box
     ai_section:
       name: AI Settings
       description: AI settings for the analysis.
@@ -660,6 +683,7 @@ action:
     generate_title: !input store_in_timeline
     include_filename: false
     max_frames: !input max_frames
+    keyframe_grace: !input keyframe_grace
     target_width: !input target_width
     max_tokens: !input max_tokens
   response_variable: response

--- a/custom_components/llmvision/__init__.py
+++ b/custom_components/llmvision/__init__.py
@@ -3,6 +3,7 @@ from .timeline import Timeline
 from .providers import Request
 from .memory import Memory
 from .media_handlers import MediaProcessor
+from . import keyframe_registry
 import os, re
 from datetime import timedelta
 from homeassistant.util import dt as dt_util
@@ -31,6 +32,8 @@ from .const import (
     CONF_AZURE_DEPLOYMENT,
     CONF_CUSTOM_OPENAI_ENDPOINT,
     CONF_RETENTION_TIME,
+    CONF_CLEANUP_GRACE,
+    DEFAULT_CLEANUP_GRACE,
     CONF_MEMORY_PATHS,
     CONF_MEMORY_IMAGES_ENCODED,
     CONF_MEMORY_STRINGS,
@@ -57,6 +60,7 @@ from .const import (
     EXPOSE_IMAGES,
     GENERATE_TITLE,
     SENSOR_ENTITY,
+    KEYFRAME_GRACE,
     DATA_EXTRACTION_PROMPT,
     DEFAULT_OPENAI_MODEL,
     DEFAULT_ANTHROPIC_MODEL,
@@ -141,6 +145,11 @@ async def async_setup_entry(hass, entry):
 
     # If this is the Settings entry, set up the calendar and run cleanup
     if filtered_provider_config.get(CONF_PROVIDER) == "Settings":
+        # Cache the configured key-frame cleanup grace for fast lookup from the
+        # (per-call) Timeline/MediaProcessor instances.
+        keyframe_registry.set_cleanup_grace(
+            hass, entry.data.get(CONF_CLEANUP_GRACE, DEFAULT_CLEANUP_GRACE)
+        )
         await hass.config_entries.async_forward_entry_setups(entry, ["calendar"])
         timeline = Timeline(hass, entry)
         await timeline._cleanup()
@@ -477,6 +486,12 @@ class ServiceCallData:
         self.max_tokens: int = int(data_call.data.get(MAXTOKENS, 3000))
         self.include_filename: bool = data_call.data.get(INCLUDE_FILENAME, False)
         self.expose_images: bool = data_call.data.get(EXPOSE_IMAGES, False)
+        # Per-call key-frame cleanup grace override (seconds). 0/unset -> use
+        # the global CONF_CLEANUP_GRACE setting.
+        _kf_grace = data_call.data.get(KEYFRAME_GRACE)
+        self.keyframe_grace = (
+            float(_kf_grace) if _kf_grace not in (None, 0, "0", "") else None
+        )
         self.generate_title: bool = data_call.data.get(GENERATE_TITLE, False)
         self.sensor_entity: str = data_call.data.get(SENSOR_ENTITY, "")
         self.response_format: str = data_call.data.get(RESPONSE_FORMAT, "text")
@@ -686,6 +701,7 @@ def setup(hass, config):
         )
         # Fetch and preprocess images
         processor = MediaProcessor(hass, request)
+        processor.keyframe_grace = call.keyframe_grace
         # Send images to RequestHandler client
         request = await processor.add_images(
             image_entities=call.image_entities,
@@ -728,6 +744,7 @@ def setup(hass, config):
             temperature=call.temperature,
         )
         processor = MediaProcessor(hass, request)
+        processor.keyframe_grace = call.keyframe_grace
         request = await processor.add_videos(
             video_paths=call.video_paths,
             event_ids=call.event_id,
@@ -767,6 +784,7 @@ def setup(hass, config):
             temperature=call.temperature,
         )
         processor = MediaProcessor(hass, request)
+        processor.keyframe_grace = call.keyframe_grace
 
         request = await processor.add_streams(
             image_entities=call.image_entities,
@@ -848,6 +866,7 @@ def setup(hass, config):
             temperature=call.temperature,
         )
         processor = MediaProcessor(hass, request)
+        processor.keyframe_grace = call.keyframe_grace
         request = await processor.add_visual_data(
             image_entities=call.image_entities,
             image_paths=call.image_paths,

--- a/custom_components/llmvision/config_flow.py
+++ b/custom_components/llmvision/config_flow.py
@@ -31,6 +31,8 @@ from .const import (
     CONF_AZURE_DEPLOYMENT,
     CONF_CUSTOM_OPENAI_ENDPOINT,
     CONF_RETENTION_TIME,
+    CONF_CLEANUP_GRACE,
+    DEFAULT_CLEANUP_GRACE,
     CONF_TIMELINE_LANGUAGE,
     CONF_FALLBACK_PROVIDER,
     CONF_MEMORY_PATHS,
@@ -1288,17 +1290,7 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         _LOGGER.debug("Settings step")
         domain_data = self.hass.data.get(DOMAIN) or {}
         _LOGGER.debug(f"Domain data: {domain_data}")
-        fallback_options = [{"label": "No Fallback", "value": "no_fallback"}]
-        for entry_id, entry_data in domain_data.items():
-            provider_label = entry_data.get(CONF_PROVIDER, entry_id)
-            if provider_label in ("Settings", "Timeline"):
-                continue
-            fallback_options.append(
-                {
-                    "label": provider_label,
-                    "value": entry_id,
-                }
-            )
+        fallback_options = _fallback_provider_options(self.hass)
         _LOGGER.debug(f"Fallback options: {fallback_options}")
         data_schema = vol.Schema(
             {
@@ -1309,33 +1301,7 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                             vol.Optional(
                                 CONF_FALLBACK_PROVIDER, default="no_fallback"
                             ): selector(
-                                {
-                                    "select": {
-                                        "options": (
-                                            [
-                                                {
-                                                    "label": "No Fallback",
-                                                    "value": "no_fallback",
-                                                }
-                                            ]
-                                            + [
-                                                {
-                                                    "label": self.hass.data[DOMAIN]
-                                                    .get(provider, {})
-                                                    .get(CONF_PROVIDER, provider),
-                                                    "value": provider,
-                                                }
-                                                for provider in (
-                                                    self.hass.data.get(DOMAIN) or {}
-                                                ).keys()
-                                                if self.hass.data[DOMAIN]
-                                                .get(provider, {})
-                                                .get(CONF_PROVIDER, provider)
-                                                not in ("Settings", "Timeline")
-                                            ]
-                                        )
-                                    }
-                                }
+                                {"select": {"options": fallback_options}}
                             ),
                             vol.Optional(CONF_REQUEST_TIMEOUT, default=60): selector(
                                 {
@@ -1408,6 +1374,19 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                                     }
                                 }
                             ),
+                            vol.Optional(
+                                CONF_CLEANUP_GRACE, default=DEFAULT_CLEANUP_GRACE
+                            ): selector(
+                                {
+                                    "number": {
+                                        "min": 10,
+                                        "max": 3600,
+                                        "step": 10,
+                                        "unit_of_measurement": "seconds",
+                                        "mode": "box",
+                                    }
+                                }
+                            ),
                         }
                     ),
                     {"collapsed": True},
@@ -1457,6 +1436,9 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_TIMELINE_LANGUAGE, "English"
                 ),
                 CONF_RETENTION_TIME: self.init_info.get(CONF_RETENTION_TIME, 7),
+                CONF_CLEANUP_GRACE: self.init_info.get(
+                    CONF_CLEANUP_GRACE, DEFAULT_CLEANUP_GRACE
+                ),
                 # CONF_TIMELINE_TODAY_SUMMARY: self.init_info.get(CONF_TIMELINE_TODAY_SUMMARY, False),
                 # CONF_TIMELINE_SUMMARY_PROMPT: self.init_info.get(
                 #     CONF_TIMELINE_SUMMARY_PROMPT, DEFAULT_SUMMARY_PROMPT),
@@ -1640,6 +1622,26 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 
 # Helper functions
+def _fallback_provider_options(hass) -> list[dict]:
+    """Build the fallback-provider dropdown options.
+
+    Each option is labelled with the provider config entry's *title*
+    (e.g. "Ollama (host:port)") so multiple providers of the same type are
+    distinguishable, falling back to the provider type when the entry cannot be
+    resolved. The Settings/Timeline pseudo-entries are excluded.
+    """
+    options = [{"label": "No Fallback", "value": "no_fallback"}]
+    for entry_id, entry_data in (hass.data.get(DOMAIN) or {}).items():
+        provider_type = entry_data.get(CONF_PROVIDER, entry_id)
+        if provider_type in ("Settings", "Timeline"):
+            continue
+        entry = hass.config_entries.async_get_entry(entry_id)
+        title = getattr(entry, "title", None)
+        label = title if isinstance(title, str) and title else provider_type
+        options.append({"label": label, "value": entry_id})
+    return options
+
+
 def flatten_dict(data: dict) -> dict:
     """Flatten one level of nested dicts (from section fields) into the top-level dict."""
     flat = {}

--- a/custom_components/llmvision/const.py
+++ b/custom_components/llmvision/const.py
@@ -34,6 +34,10 @@ CONF_CUSTOM_OPENAI_ENDPOINT = "custom_openai_endpoint"
 
 # Timeline
 CONF_RETENTION_TIME = "retention_time"
+# Seconds a freshly-written key-frame snapshot is protected from the timeline
+# cleanup before it is considered an orphan. Must exceed the analysis duration,
+# otherwise the key frame is swept before its event row is inserted.
+CONF_CLEANUP_GRACE = "cleanup_grace"
 
 # Settings
 CONF_TIMELINE_LANGUAGE = "timeline_language"
@@ -79,6 +83,9 @@ INCLUDE_FILENAME = "include_filename"
 EXPOSE_IMAGES = "expose_images"
 GENERATE_TITLE = "generate_title"
 SENSOR_ENTITY = "sensor_entity"
+# Per-call override for the key-frame cleanup grace (seconds). Falls back to the
+# global CONF_CLEANUP_GRACE setting when 0/unset.
+KEYFRAME_GRACE = "keyframe_grace"
 
 # Error messages
 ERROR_NOT_CONFIGURED = "{provider} is not configured"
@@ -91,6 +98,10 @@ VERSION_ANTHROPIC = "2023-06-01"  # https://docs.anthropic.com/en/api/versioning
 VERSION_AZURE = "2025-04-01-preview"  # https://learn.microsoft.com/en-us/azure/ai-foundry/openai/api-version-lifecycle?tabs=key
 
 # Defaults
+# Default key-frame cleanup grace, in seconds. 300s comfortably covers slow
+# multi-frame analyses (e.g. stream_analyzer with high max_frames on a local
+# model) while still pruning genuinely orphaned snapshots from failed runs.
+DEFAULT_CLEANUP_GRACE = 300
 DEFAULT_SYSTEM_PROMPT = "Analyze the images and give a concise, objective event summary (<255 chars). Focus on people, pets, and moving objects; track changes across images. Exclude static details, avoid speculation, and follow user instructions."
 DEFAULT_TITLE_PROMPT = "Generate a clear event title (<6 words) from the description. Use format: <Object> seen at <location>. Keep it concise, factual, and alert-ready. Include names if given. Avoid extra details or interpretations."
 DATA_EXTRACTION_PROMPT = "Analyze the image(s) and extract only the requested info (e.g., object count, license plate). Output strictly in {data_format}. Double-check accuracy and ensure results reflect the image content. Do not explain or add extra info."

--- a/custom_components/llmvision/keyframe_registry.py
+++ b/custom_components/llmvision/keyframe_registry.py
@@ -1,0 +1,135 @@
+"""Shared, hass-global protection registry for in-flight key-frame snapshots.
+
+Background
+----------
+``MediaProcessor._expose_image`` writes a key-frame snapshot to
+``/media/llmvision/snapshots`` at the *start* of an analysis, but the matching
+timeline event (which "links" the file and protects it from cleanup) is only
+inserted at the *end*, after the LLM call returns. A ``Timeline`` object is
+constructed per service call and per timeline API request, and each construction
+schedules ``Timeline._cleanup()``. That cleanup deletes any snapshot that is not
+linked to an event and is older than the grace window -- so for any analysis that
+runs longer than the grace window, the key frame is swept *before* its event
+exists, and the card/notification end up pointing at a missing file.
+
+A per-instance ``_pending_key_frames`` set cannot fix this because the writer,
+the inserter and the cleaner are three different ``Timeline``/``MediaProcessor``
+objects. This module keeps the protection list in ``hass.data[DOMAIN]`` so every
+instance sees the same set, with a TTL so a failed analysis cannot leak a file
+forever.
+"""
+
+import os
+import time
+
+from .const import (
+    CONF_CLEANUP_GRACE,
+    CONF_PROVIDER,
+    DEFAULT_CLEANUP_GRACE,
+    DOMAIN,
+)
+
+_PENDING_KEY = "_pending_key_frames"
+_GRACE_KEY = "_cleanup_grace"
+
+
+def _basename(key_frame: str) -> str:
+    return (os.path.basename(key_frame) or "").lower() if key_frame else ""
+
+
+def _domain_data(hass) -> dict | None:
+    """Return hass.data[DOMAIN] (creating it), or None if hass.data isn't a dict.
+
+    Defensive: some unit tests pass a bare ``Mock`` as ``hass.data``; production
+    always has a real dict.
+    """
+    data = getattr(hass, "data", None)
+    if not isinstance(data, dict):
+        return None
+    domain_data = data.get(DOMAIN)
+    if not isinstance(domain_data, dict):
+        domain_data = {}
+        data[DOMAIN] = domain_data
+    return domain_data
+
+
+def _registry(hass) -> dict:
+    """Return the (lazily created) basename -> expiry-timestamp map."""
+    domain_data = _domain_data(hass)
+    if domain_data is None:
+        return {}
+    reg = domain_data.get(_PENDING_KEY)
+    if not isinstance(reg, dict):
+        reg = {}
+        domain_data[_PENDING_KEY] = reg
+    return reg
+
+
+def protect(hass, key_frame: str, ttl: float | None = None) -> None:
+    """Protect ``key_frame`` (by basename) from cleanup for up to ``ttl`` seconds.
+
+    Call this the moment the snapshot is written, before the (slow) analysis
+    runs. ``ttl`` defaults to the configured global cleanup grace.
+    """
+    base = _basename(key_frame)
+    if not base:
+        return
+    if ttl is None:
+        ttl = get_cleanup_grace(hass)
+    try:
+        ttl = float(ttl)
+    except (TypeError, ValueError):
+        ttl = float(DEFAULT_CLEANUP_GRACE)
+    _registry(hass)[base] = time.time() + max(0.0, ttl)
+
+
+def release(hass, key_frame: str) -> None:
+    """Drop protection for ``key_frame`` once its event row exists.
+
+    After the event is inserted the file is "linked", so the normal
+    linked-file protection takes over and the TTL entry is no longer needed.
+    """
+    base = _basename(key_frame)
+    if base:
+        _registry(hass).pop(base, None)
+
+
+def protected_basenames(hass) -> set:
+    """Return basenames still under (unexpired) protection, pruning expired ones."""
+    reg = _registry(hass)
+    now = time.time()
+    for base in [b for b, exp in reg.items() if exp <= now]:
+        reg.pop(base, None)
+    return set(reg.keys())
+
+
+def set_cleanup_grace(hass, seconds) -> None:
+    """Store the configured global cleanup grace (seconds) for this install."""
+    try:
+        seconds = float(seconds)
+    except (TypeError, ValueError):
+        seconds = float(DEFAULT_CLEANUP_GRACE)
+    domain_data = _domain_data(hass)
+    if domain_data is not None:
+        domain_data[_GRACE_KEY] = max(0.0, seconds)
+
+
+def get_cleanup_grace(hass) -> float:
+    """Return the configured global cleanup grace (seconds).
+
+    Falls back to the Settings config entry, then ``DEFAULT_CLEANUP_GRACE``.
+    """
+    data = hass.data.get(DOMAIN) if isinstance(getattr(hass, "data", None), dict) else None
+    if isinstance(data, dict) and _GRACE_KEY in data:
+        return data[_GRACE_KEY]
+    # Fall back to reading the Settings entry directly (cleanup can run before
+    # async_setup_entry has cached the value).
+    try:
+        for entry in hass.config_entries.async_entries(DOMAIN):
+            if entry.data.get(CONF_PROVIDER) == "Settings":
+                return float(
+                    entry.data.get(CONF_CLEANUP_GRACE, DEFAULT_CLEANUP_GRACE)
+                )
+    except Exception:  # noqa: BLE001 - never let cleanup-grace lookup break cleanup
+        pass
+    return float(DEFAULT_CLEANUP_GRACE)

--- a/custom_components/llmvision/media_handlers.py
+++ b/custom_components/llmvision/media_handlers.py
@@ -23,6 +23,7 @@ from homeassistant.helpers.network import get_url
 from homeassistant.exceptions import ServiceValidationError
 
 from .const import DOMAIN
+from . import keyframe_registry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,6 +37,9 @@ class MediaProcessor:
         self.filenames = []
         self.snapshots_path = f"/media/{DOMAIN}/snapshots/"
         self.key_frame = ""
+        # Per-call override for the key-frame cleanup grace (seconds). None ->
+        # use the configured global grace. Set by the service handlers.
+        self.keyframe_grace = None
 
     async def _encode_image(self, img):
         """Encode image as base64"""
@@ -83,6 +87,12 @@ class MediaProcessor:
         if self.key_frame == "":
             filename = f"/media/{DOMAIN}/snapshots/{uid}-{frame_name}.jpg"
             self.key_frame = filename
+            # Protect the key frame from the timeline cleanup for the whole
+            # analysis window. Without this the file is written here but only
+            # "linked" to an event much later (after the LLM call), so a cleanup
+            # firing in between would delete it as an orphan. Protection is
+            # released when the event is inserted (see timeline.add_event).
+            keyframe_registry.protect(self.hass, filename, self.keyframe_grace)
             if image_data is None and frame_path is not None:
                 # open image in hass.loop
                 with await self.hass.loop.run_in_executor(

--- a/custom_components/llmvision/services.yaml
+++ b/custom_components/llmvision/services.yaml
@@ -99,6 +99,24 @@ image_analyzer:
       default: false
       selector:
         boolean:
+    keyframe_grace:
+      name: Key Frame Retention Grace
+      description: >-
+        Seconds to protect the saved key frame from cleanup while the analysis
+        runs. Leave at 0 to use the global "Snapshot cleanup grace" setting.
+        Increase for slow analyses (high max_frames / long duration): if this is
+        shorter than the analysis takes, the key frame can be deleted before its
+        timeline event is saved, leaving notifications/cards without an image.
+      required: false
+      example: 300
+      default: 0
+      selector:
+        number:
+          min: 0
+          max: 3600
+          step: 10
+          unit_of_measurement: seconds
+          mode: box
     response_format:
       name: Response Format
       description: Format of the response - text for natural language or json for structured data
@@ -246,6 +264,24 @@ video_analyzer:
       default: false
       selector:
         boolean:
+    keyframe_grace:
+      name: Key Frame Retention Grace
+      description: >-
+        Seconds to protect the saved key frame from cleanup while the analysis
+        runs. Leave at 0 to use the global "Snapshot cleanup grace" setting.
+        Increase for slow analyses (high max_frames / long duration): if this is
+        shorter than the analysis takes, the key frame can be deleted before its
+        timeline event is saved, leaving notifications/cards without an image.
+      required: false
+      example: 300
+      default: 0
+      selector:
+        number:
+          min: 0
+          max: 3600
+          step: 10
+          unit_of_measurement: seconds
+          mode: box
     response_format:
       name: Response Format
       description: Format of the response - text for natural language or json for structured data
@@ -396,6 +432,24 @@ stream_analyzer:
       default: false
       selector:
         boolean:
+    keyframe_grace:
+      name: Key Frame Retention Grace
+      description: >-
+        Seconds to protect the saved key frame from cleanup while the analysis
+        runs. Leave at 0 to use the global "Snapshot cleanup grace" setting.
+        Increase for slow analyses (high max_frames / long duration): if this is
+        shorter than the analysis takes, the key frame can be deleted before its
+        timeline event is saved, leaving notifications/cards without an image.
+      required: false
+      example: 300
+      default: 0
+      selector:
+        number:
+          min: 0
+          max: 3600
+          step: 10
+          unit_of_measurement: seconds
+          mode: box
     response_format:
       name: Response Format
       description: Format of the response - text for natural language or json for structured data
@@ -543,6 +597,24 @@ data_analyzer:
       default: false
       selector:
         boolean:
+    keyframe_grace:
+      name: Key Frame Retention Grace
+      description: >-
+        Seconds to protect the saved key frame from cleanup while the analysis
+        runs. Leave at 0 to use the global "Snapshot cleanup grace" setting.
+        Increase for slow analyses (high max_frames / long duration): if this is
+        shorter than the analysis takes, the key frame can be deleted before its
+        timeline event is saved, leaving notifications/cards without an image.
+      required: false
+      example: 300
+      default: 0
+      selector:
+        number:
+          min: 0
+          max: 3600
+          step: 10
+          unit_of_measurement: seconds
+          mode: box
 
 create_event:
   name: Create Event

--- a/custom_components/llmvision/strings.json
+++ b/custom_components/llmvision/strings.json
@@ -393,12 +393,14 @@
                         "data": {
                             "timeline_language": "Timeline language",
                             "retention_time": "Retention time",
+                            "cleanup_grace": "Snapshot cleanup grace (seconds)",
                             "timeline_today_summary": "Timeline Summary",
                             "timeline_summary_prompt": "Today Summary Prompt"
                         },
                         "data_description": {
                             "timeline_language": "Select the language used to generate icons from events.",
                             "retention_time": "Auto delete events after (days). Set to 0 to disable auto deletion.",
+                            "cleanup_grace": "How long a freshly-saved key-frame snapshot is protected from cleanup while analysis runs. Must exceed your analysis time: increase it if you use a high frame count or long duration, otherwise key-frame images can be deleted before their event is saved (missing card/notification images).",
                             "timeline_today_summary": "Enable timeline summary to automatically generate a summary of today's events.",
                             "timeline_summary_prompt": "The instruction given to the model to generate a summary of today's events."
                         }

--- a/custom_components/llmvision/timeline.py
+++ b/custom_components/llmvision/timeline.py
@@ -6,6 +6,7 @@ import os, re
 import json
 import asyncio
 from .const import DOMAIN, CONF_RETENTION_TIME, CONF_TIMELINE_LANGUAGE
+from . import keyframe_registry
 from homeassistant.util import dt as dt_util
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
@@ -840,6 +841,9 @@ class Timeline:
                 )
                 _LOGGER.info(f"Creating event: {event}")
                 await self._insert_event(event)
+                # Event row now exists, so the file is "linked" and protected
+                # by that. Release the registry hold taken at write time.
+                keyframe_registry.release(self.hass, key_frame)
             finally:
                 # Remove from pending once DB insert is done
                 if pending_name:
@@ -974,13 +978,21 @@ class Timeline:
             # Skip cleanup during migration
             return
 
-        GRACE_SECONDS = 10
+        # Grace window (seconds) a freshly-written snapshot is protected before
+        # it is treated as an orphan. Configurable via the LLM Vision Settings
+        # ("Snapshot cleanup grace") and per-call via the analyzer services.
+        # It MUST exceed the analysis duration, otherwise a key frame can be
+        # swept after it is written but before its event row is inserted.
+        grace_seconds = keyframe_registry.get_cleanup_grace(self.hass)
 
         async with self._cleanup_lock:
             linked_frames = {
                 (os.path.basename(n) or "").lower()
                 for n in await self.get_linked_images()
             }
+            # Basenames of key frames written but not yet linked to an event
+            # (analysis in flight), shared across all Timeline instances.
+            protected_frames = keyframe_registry.protected_basenames(self.hass)
 
             # List files in snapshots dir (in executor, non-blocking)
             try:
@@ -1003,8 +1015,13 @@ class Timeline:
 
                 base = (file or "").lower()
 
-                # Protect if linked to an event or pending
-                if base in linked_frames or base in self._pending_key_frames:
+                # Protect if linked to an event, pending in this instance, or
+                # protected in the shared in-flight registry.
+                if (
+                    base in linked_frames
+                    or base in self._pending_key_frames
+                    or base in protected_frames
+                ):
                     continue
 
                 # Protect new files (grace window)
@@ -1012,7 +1029,7 @@ class Timeline:
                     mtime = await self.hass.async_add_executor_job(
                         os.path.getmtime, file_path
                     )
-                    if (now_ts - mtime) < GRACE_SECONDS:
+                    if (now_ts - mtime) < grace_seconds:
                         continue
                 except OSError:
                     continue

--- a/custom_components/llmvision/translations/en.json
+++ b/custom_components/llmvision/translations/en.json
@@ -393,12 +393,14 @@
                         "data": {
                             "timeline_language": "Timeline language",
                             "retention_time": "Retention time",
+                            "cleanup_grace": "Snapshot cleanup grace (seconds)",
                             "timeline_today_summary": "Timeline Summary",
                             "timeline_summary_prompt": "Today Summary Prompt"
                         },
                         "data_description": {
                             "timeline_language": "Select the language used to generate icons from events.",
                             "retention_time": "Auto delete events after (days). Set to 0 to disable auto deletion.",
+                            "cleanup_grace": "How long a freshly-saved key-frame snapshot is protected from cleanup while analysis runs. Must exceed your analysis time: increase it if you use a high frame count or long duration, otherwise key-frame images can be deleted before their event is saved (missing card/notification images).",
                             "timeline_today_summary": "Enable timeline summary to automatically generate a summary of today's events.",
                             "timeline_summary_prompt": "The instruction given to the model to generate a summary of today's events."
                         }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -6,7 +6,11 @@ import pytest
 from homeassistant import config_entries
 from homeassistant.exceptions import ServiceValidationError
 
-from custom_components.llmvision.config_flow import flatten_dict, llmvisionConfigFlow
+from custom_components.llmvision.config_flow import (
+    flatten_dict,
+    llmvisionConfigFlow,
+    _fallback_provider_options,
+)
 from custom_components.llmvision.const import (
     CONF_API_KEY,
     CONF_AWS_ACCESS_KEY_ID,
@@ -953,3 +957,49 @@ class TestFlattenDict:
         result = flatten_dict(flat)
 
         assert result == flat
+
+
+class TestFallbackProviderOptions:
+    """The fallback-provider dropdown must label options with the entry title so
+    multiple providers of the same type (e.g. two Ollama servers) are
+    distinguishable, not collapsed to the bare provider type."""
+
+    def test_labels_use_entry_title_for_same_type_providers(self, mock_hass):
+        mock_hass.data = {
+            "llmvision": {
+                "ollama-1": {CONF_PROVIDER: "Ollama"},
+                "ollama-2": {CONF_PROVIDER: "Ollama"},
+                "settings": {CONF_PROVIDER: "Settings"},
+            }
+        }
+        entries = {
+            "ollama-1": Mock(title="Ollama (Datawatch:100.64.0.20)"),
+            "ollama-2": Mock(title="Ollama (JohnnyJohnny:100.64.0.4)"),
+        }
+        mock_hass.config_entries.async_get_entry = Mock(
+            side_effect=lambda eid: entries.get(eid)
+        )
+
+        opts = _fallback_provider_options(mock_hass)
+        labels = [o["label"] for o in opts]
+        values = [o["value"] for o in opts]
+
+        assert "No Fallback" in labels
+        assert "Ollama (Datawatch:100.64.0.20)" in labels
+        assert "Ollama (JohnnyJohnny:100.64.0.4)" in labels
+        # The two same-type providers are NOT collapsed to one "Ollama" label.
+        assert labels.count("Ollama") == 0
+        assert "ollama-1" in values and "ollama-2" in values
+        assert "settings" not in values  # Settings pseudo-entry excluded
+
+    def test_falls_back_to_type_when_entry_unresolved(self, mock_hass):
+        mock_hass.data = {"llmvision": {"ollama-x": {CONF_PROVIDER: "Ollama"}}}
+        mock_hass.config_entries.async_get_entry = Mock(return_value=None)
+        opts = _fallback_provider_options(mock_hass)
+        assert {"label": "Ollama", "value": "ollama-x"} in opts
+
+    def test_only_no_fallback_when_no_providers(self, mock_hass):
+        mock_hass.data = {"llmvision": {"settings": {CONF_PROVIDER: "Settings"}}}
+        mock_hass.config_entries.async_get_entry = Mock(return_value=None)
+        opts = _fallback_provider_options(mock_hass)
+        assert opts == [{"label": "No Fallback", "value": "no_fallback"}]

--- a/tests/test_keyframe_registry.py
+++ b/tests/test_keyframe_registry.py
@@ -1,0 +1,108 @@
+"""Unit tests for the shared key-frame protection registry.
+
+These are pure-logic tests (no Home Assistant runtime needed) covering the
+mechanism that fixes the key-frame cleanup race: a snapshot written at the
+start of an analysis must stay protected until its timeline event is inserted,
+regardless of how long the (slow) analysis runs.
+"""
+import time
+
+import pytest
+
+from custom_components.llmvision import keyframe_registry as kr
+from custom_components.llmvision.const import (
+    CONF_CLEANUP_GRACE,
+    CONF_PROVIDER,
+    DEFAULT_CLEANUP_GRACE,
+    DOMAIN,
+)
+
+
+class _FakeConfigEntries:
+    def __init__(self, entries):
+        self._entries = entries
+
+    def async_entries(self, domain):
+        return self._entries
+
+
+class _FakeHass:
+    """Minimal stand-in: the registry only needs ``.data`` and ``.config_entries``."""
+
+    def __init__(self, entries=None):
+        self.data = {}
+        self.config_entries = _FakeConfigEntries(entries or [])
+
+
+class _FakeEntry:
+    def __init__(self, data):
+        self.data = data
+
+
+def test_protect_then_listed_then_released():
+    hass = _FakeHass()
+    kf = "/media/llmvision/snapshots/abc123-camera0.jpg"
+    kr.protect(hass, kf, ttl=100)
+    assert "abc123-camera0.jpg" in kr.protected_basenames(hass)
+    kr.release(hass, kf)
+    assert "abc123-camera0.jpg" not in kr.protected_basenames(hass)
+
+
+def test_protect_uses_lowercased_basename():
+    hass = _FakeHass()
+    kr.protect(hass, "/x/AbC-Camera0.JPG", ttl=100)
+    assert "abc-camera0.jpg" in kr.protected_basenames(hass)
+
+
+def test_expired_entries_are_pruned():
+    hass = _FakeHass()
+    kr.protect(hass, "/x/expire-me.jpg", ttl=0.01)
+    time.sleep(0.05)
+    assert "expire-me.jpg" not in kr.protected_basenames(hass)
+    # The backing dict is actually pruned, not just filtered.
+    assert "expire-me.jpg" not in hass.data[DOMAIN][kr._PENDING_KEY]
+
+
+def test_empty_or_none_keyframe_is_noop():
+    hass = _FakeHass()
+    kr.protect(hass, "", ttl=100)
+    kr.protect(hass, None, ttl=100)
+    kr.release(hass, "")  # must not raise
+    assert kr.protected_basenames(hass) == set()
+
+
+def test_get_grace_defaults_when_unset():
+    hass = _FakeHass()
+    assert kr.get_cleanup_grace(hass) == float(DEFAULT_CLEANUP_GRACE)
+
+
+def test_set_and_get_cleanup_grace():
+    hass = _FakeHass()
+    kr.set_cleanup_grace(hass, 450)
+    assert kr.get_cleanup_grace(hass) == 450.0
+
+
+def test_get_grace_falls_back_to_settings_entry():
+    hass = _FakeHass(
+        entries=[_FakeEntry({CONF_PROVIDER: "Settings", CONF_CLEANUP_GRACE: 222})]
+    )
+    assert kr.get_cleanup_grace(hass) == 222.0
+
+
+def test_protect_ttl_none_uses_global_grace():
+    hass = _FakeHass()
+    kr.set_cleanup_grace(hass, 30)
+    before = time.time()
+    kr.protect(hass, "/x/k.jpg", ttl=None)
+    expiry = hass.data[DOMAIN][kr._PENDING_KEY]["k.jpg"]
+    assert 29 <= (expiry - before) <= 31
+
+
+def test_bad_grace_value_falls_back_to_default():
+    hass = _FakeHass()
+    kr.set_cleanup_grace(hass, "not-a-number")
+    assert kr.get_cleanup_grace(hass) == float(DEFAULT_CLEANUP_GRACE)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -19,6 +19,7 @@ from custom_components.llmvision.timeline import (
     Timeline,
     _get_category_and_label,
 )
+from custom_components.llmvision import keyframe_registry
 from homeassistant.util import dt as dt_util
 
 # ---------------------------------------------------------------------------
@@ -1017,6 +1018,10 @@ class TestCleanup:
         media_path.mkdir()
         tl._media_path = str(media_path)
 
+        # Pin the (now configurable) grace so the orphan age is unambiguously
+        # outside the protection window regardless of the default.
+        keyframe_registry.set_cleanup_grace(tl.hass, 10)
+
         orphan = media_path / "orphan.jpg"
         orphan.write_bytes(b"fake")
         old_ts = datetime.datetime.now().timestamp() - 100
@@ -1109,6 +1114,89 @@ class TestCleanup:
         tl._migrating = False
         await tl._cleanup()
         assert subdir.exists()
+
+    async def test_cleanup_protects_registry_protected_frame(
+        self, build_timeline, tmp_path
+    ):
+        """Regression: a key frame written but not yet linked (analysis still
+        running) is protected via the shared registry even though it is old and
+        unlinked, then deleted once released. This is the bug that left cards
+        and notifications without images."""
+        tl = build_timeline()
+        await tl._initialize_db()
+        media_path = tmp_path / "snapshots"
+        media_path.mkdir()
+        tl._media_path = str(media_path)
+        keyframe_registry.set_cleanup_grace(tl.hass, 10)
+
+        frame = media_path / "inflight.jpg"
+        frame.write_bytes(b"fake")
+        old_ts = datetime.datetime.now().timestamp() - 100  # well past the grace
+        os.utime(str(frame), (old_ts, old_ts))
+
+        # _expose_image registers protection at write time.
+        keyframe_registry.protect(tl.hass, str(frame), ttl=100)
+
+        tl._migrating = False
+        await tl._cleanup()
+        assert frame.exists()  # survived despite being old and unlinked
+
+        # Once released (event inserted), it becomes a true orphan.
+        keyframe_registry.release(tl.hass, str(frame))
+        await tl._cleanup()
+        assert not frame.exists()
+
+    async def test_cleanup_protection_is_shared_across_instances(
+        self, build_timeline, tmp_path
+    ):
+        """Protection lives in hass.data, so a frame protected by the writer
+        survives cleanup run by a *different* Timeline instance sharing the same
+        hass (the real case: per-call / per-card-poll Timeline objects)."""
+        writer = build_timeline()
+        await writer._initialize_db()
+        media_path = tmp_path / "snapshots"
+        media_path.mkdir()
+        writer._media_path = str(media_path)
+        keyframe_registry.set_cleanup_grace(writer.hass, 10)
+
+        frame = media_path / "shared.jpg"
+        frame.write_bytes(b"fake")
+        old_ts = datetime.datetime.now().timestamp() - 100
+        os.utime(str(frame), (old_ts, old_ts))
+        keyframe_registry.protect(writer.hass, str(frame), ttl=100)
+
+        cleaner = build_timeline()
+        cleaner.hass = writer.hass  # share hass.data (and thus the registry)
+        cleaner._media_path = str(media_path)
+        cleaner._migrating = False
+        await cleaner._cleanup()
+        assert frame.exists()
+
+    async def test_cleanup_honors_configured_grace(self, build_timeline, tmp_path):
+        """The grace window is read from configuration, not hard-coded to 10s."""
+        tl = build_timeline()
+        await tl._initialize_db()
+        media_path = tmp_path / "snapshots"
+        media_path.mkdir()
+        tl._media_path = str(media_path)
+        tl._migrating = False
+
+        def _make(name):
+            p = media_path / name
+            p.write_bytes(b"fake")
+            ts = datetime.datetime.now().timestamp() - 60  # 60s old, unlinked
+            os.utime(str(p), (ts, ts))
+            return p
+
+        short = _make("short_grace.jpg")
+        keyframe_registry.set_cleanup_grace(tl.hass, 30)
+        await tl._cleanup()
+        assert not short.exists()  # 60s > 30s grace -> removed
+
+        long = _make("long_grace.jpg")
+        keyframe_registry.set_cleanup_grace(tl.hass, 600)
+        await tl._cleanup()
+        assert long.exists()  # 60s < 600s grace -> kept
 
 
 # ===========================================================================


### PR DESCRIPTION
## Problem

On installs where an analysis runs longer than ~10 seconds (e.g. `stream_analyzer`
with a high `max_frames`/`duration`, or a slower local model), the key-frame
snapshot for a timeline event is **deleted before the event is saved**. The result
is blank thumbnails in the LLM Vision Card and image-less notifications — even
though the analysis succeeds and the timeline event is created and shows the
summary text.

### Root cause (diagnosed on v1.7.0)

`MediaProcessor._expose_image()` writes the key frame to
`/media/llmvision/snapshots/` at the **start** of an analysis, but the event that
"links" the file (and protects it from cleanup) is only inserted at the **end**,
after the LLM call returns. Meanwhile:

- A new `Timeline()` is constructed **per service call and per timeline API / card
  poll** (`__init__._create_event`, `api.py`, `calendar.py`), and each
  construction schedules `Timeline._cleanup()` as a background task.
- `_cleanup()` deletes any snapshot in the directory that is not linked to an
  event and is older than a hard-coded `GRACE_SECONDS = 10`.

So for any analysis longer than 10s, the freshly-written key frame ages past the
grace window while still unlinked, and a cleanup — fired by the very
event-creation flow, or by the card polling the timeline — removes it. The DB
event is then left pointing at a missing file.

Reproduced live: a `stream_analyzer` key frame written at T+0 was consistently
deleted at exactly T+10s (the grace boundary) while the analysis was still
running. With the fix it persists and links correctly. Instances that only ran
fast analyses (few frames) never hit the window, which is why this looked
intermittent.

## Changes

1. **Shared in-flight key-frame registry** (`keyframe_registry.py`). Protection
   now lives in `hass.data[DOMAIN]`, so the writer, the inserter and the cleaner
   (three different `Timeline`/`MediaProcessor` instances) all see the same set.
   `_expose_image` registers the frame the moment it is written; `create_event`
   releases it once the row is inserted; entries are TTL-bounded so a failed
   analysis cannot leak files. `_cleanup` consults this across all instances, so
   the race is fixed regardless of how often cleanup fires.

2. **Configurable cleanup grace** — `CONF_CLEANUP_GRACE` (default **300s**) in
   LLM Vision Settings → Timeline, replacing the hard-coded `GRACE_SECONDS = 10`.

3. **Per-call override** — `keyframe_grace` service field on the analyzer
   services, surfaced as a blueprint input after **Max Frames** with guidance to
   raise it alongside Duration / Max Frames. `0` = use the global setting.

4. **Fallback-provider dropdown labels** now use the config-entry **title**
   (e.g. `Ollama (host:port)`) instead of the bare provider type, so multiple
   providers of the same type are distinguishable. Extracted to a testable
   `_fallback_provider_options()` helper.

## Tests

- New `tests/test_keyframe_registry.py` (9 tests).
- New `_cleanup` regression tests: registry-protected frame survives while
  unlinked then is removed once released; protection is shared across `Timeline`
  instances; configurable grace is honored (not hard-coded).
- New fallback-provider label tests.
- Full suite green on Python 3.13: `pytest tests/ -m "not integration"` → 423 passed.

## Notes

- Default grace of 300s comfortably covers slow multi-frame analyses while still
  pruning genuinely orphaned snapshots from failed runs.
- Both `event_summary.yaml` and `event_summary_beta.yaml` blueprints are updated
  consistently (new input + analyzer wiring + duration/max_frames guidance).
- No schema is attached to the analyzer services, so the new `keyframe_grace`
  field is backward/forward compatible (ignored by older code).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
