### PR TITLE
Feat/add litellm provider

### DIFF
--- a/custom_components/llmvision/config_flow.py
+++ b/custom_components/llmvision/config_flow.py
@@ -54,6 +54,8 @@ from .const import (
     DEFAULT_AWS_MODEL,
     DEFAULT_OPENWEBUI_MODEL,
     DEFAULT_OPENROUTER_MODEL,
+    DEFAULT_LITELLM_MODEL,
+    CONF_LITELLM_BASE_URL,
     ENDPOINT_OPENWEBUI,
     ENDPOINT_AZURE,
     ENDPOINT_OPENROUTER,
@@ -84,6 +86,7 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             "Groq": self.async_step_groq,
             "LocalAI": self.async_step_localai,
             "Ollama": self.async_step_ollama,
+            "LiteLLM": self.async_step_litellm,
             "OpenAI": self.async_step_openai,
             "OpenWebUI": self.async_step_openwebui,
             "OpenRouter": self.async_step_openrouter,
@@ -120,6 +123,7 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                                 "Azure",
                                 "Google",
                                 "Groq",
+                                "LiteLLM",
                                 "LocalAI",
                                 "Ollama",
                                 "OpenAI",
@@ -1629,6 +1633,110 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="openrouter",
+            data_schema=data_schema,
+        )
+
+    async def async_step_litellm(self, user_input=None):
+        data_schema = vol.Schema(
+            {
+                vol.Optional("connection_section"): section(
+                    vol.Schema(
+                        {
+                            vol.Required(CONF_API_KEY): selector(
+                                {"text": {"type": "password"}}
+                            ),
+                            vol.Required(
+                                CONF_LITELLM_BASE_URL,
+                                default="http://localhost:4000/v1/chat/completions",
+                            ): str,
+                        }
+                    ),
+                    {"collapsed": False},
+                ),
+                vol.Optional("model_section"): section(
+                    vol.Schema(
+                        {
+                            vol.Required(
+                                CONF_DEFAULT_MODEL, default=DEFAULT_LITELLM_MODEL
+                            ): str,
+                            vol.Optional(CONF_TEMPERATURE, default=0.5): selector(
+                                {
+                                    "number": {
+                                        "min": 0,
+                                        "max": 1,
+                                        "step": 0.1,
+                                        "mode": "slider",
+                                    }
+                                }
+                            ),
+                            vol.Optional(CONF_TOP_P, default=0.9): selector(
+                                {
+                                    "number": {
+                                        "min": 0,
+                                        "max": 1,
+                                        "step": 0.1,
+                                        "mode": "slider",
+                                    }
+                                }
+                            ),
+                        }
+                    ),
+                    {"collapsed": False},
+                ),
+            }
+        )
+
+        if self.source == config_entries.SOURCE_RECONFIGURE:
+            self.init_info = self._get_reconfigure_entry().data
+            suggested = {
+                "connection_section": {
+                    CONF_API_KEY: self.init_info.get(CONF_API_KEY),
+                    CONF_LITELLM_BASE_URL: self.init_info.get(
+                        CONF_LITELLM_BASE_URL,
+                        "http://localhost:4000/v1/chat/completions",
+                    ),
+                },
+                "model_section": {
+                    CONF_DEFAULT_MODEL: self.init_info.get(
+                        CONF_DEFAULT_MODEL, DEFAULT_LITELLM_MODEL
+                    ),
+                    CONF_TEMPERATURE: self.init_info.get(CONF_TEMPERATURE, 0.5),
+                    CONF_TOP_P: self.init_info.get(CONF_TOP_P, 0.9),
+                },
+            }
+            data_schema = self.add_suggested_values_to_schema(data_schema, suggested)
+
+        if user_input is not None:
+            user_input[CONF_PROVIDER] = self.init_info[CONF_PROVIDER]
+            user_input = flatten_dict(user_input)
+            try:
+                litellm = OpenAI(
+                    self.hass,
+                    api_key=user_input[CONF_API_KEY],
+                    model=user_input[CONF_DEFAULT_MODEL],
+                    endpoint={"base_url": user_input[CONF_LITELLM_BASE_URL]},
+                )
+                await litellm.validate()
+                user_input[CONF_PROVIDER] = self.init_info[CONF_PROVIDER]
+                if self.source == config_entries.SOURCE_RECONFIGURE:
+                    return self.async_update_reload_and_abort(
+                        self._get_reconfigure_entry(),
+                        data_updates=user_input,
+                    )
+                else:
+                    return self.async_create_entry(
+                        title="LiteLLM", data=user_input
+                    )
+            except ServiceValidationError as e:
+                _LOGGER.error(f"Validation failed: {e}")
+                return self.async_show_form(
+                    step_id="litellm",
+                    data_schema=data_schema,
+                    errors={"base": "handshake_failed"},
+                )
+
+        return self.async_show_form(
+            step_id="litellm",
             data_schema=data_schema,
         )
 

--- a/custom_components/llmvision/config_flow.py
+++ b/custom_components/llmvision/config_flow.py
@@ -15,6 +15,7 @@ from .providers import (
     LocalAI,
     Ollama,
     AWSBedrock,
+    LiteLLM,
 )
 from .const import (
     DOMAIN,
@@ -55,7 +56,6 @@ from .const import (
     DEFAULT_OPENWEBUI_MODEL,
     DEFAULT_OPENROUTER_MODEL,
     DEFAULT_LITELLM_MODEL,
-    CONF_LITELLM_BASE_URL,
     ENDPOINT_OPENWEBUI,
     ENDPOINT_AZURE,
     ENDPOINT_OPENROUTER,
@@ -1645,10 +1645,6 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                             vol.Required(CONF_API_KEY): selector(
                                 {"text": {"type": "password"}}
                             ),
-                            vol.Required(
-                                CONF_LITELLM_BASE_URL,
-                                default="http://localhost:4000/v1/chat/completions",
-                            ): str,
                         }
                     ),
                     {"collapsed": False},
@@ -1691,10 +1687,6 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             suggested = {
                 "connection_section": {
                     CONF_API_KEY: self.init_info.get(CONF_API_KEY),
-                    CONF_LITELLM_BASE_URL: self.init_info.get(
-                        CONF_LITELLM_BASE_URL,
-                        "http://localhost:4000/v1/chat/completions",
-                    ),
                 },
                 "model_section": {
                     CONF_DEFAULT_MODEL: self.init_info.get(
@@ -1710,13 +1702,12 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             user_input[CONF_PROVIDER] = self.init_info[CONF_PROVIDER]
             user_input = flatten_dict(user_input)
             try:
-                litellm = OpenAI(
+                provider = LiteLLM(
                     self.hass,
                     api_key=user_input[CONF_API_KEY],
                     model=user_input[CONF_DEFAULT_MODEL],
-                    endpoint={"base_url": user_input[CONF_LITELLM_BASE_URL]},
                 )
-                await litellm.validate()
+                await provider.validate()
                 user_input[CONF_PROVIDER] = self.init_info[CONF_PROVIDER]
                 if self.source == config_entries.SOURCE_RECONFIGURE:
                     return self.async_update_reload_and_abort(

--- a/custom_components/llmvision/const.py
+++ b/custom_components/llmvision/const.py
@@ -32,9 +32,6 @@ CONF_AWS_REGION_NAME = "aws_region_name"
 # Custom OpenAI specific
 CONF_CUSTOM_OPENAI_ENDPOINT = "custom_openai_endpoint"
 
-# LiteLLM specific
-CONF_LITELLM_BASE_URL = "litellm_base_url"
-
 # Timeline
 CONF_RETENTION_TIME = "retention_time"
 

--- a/custom_components/llmvision/const.py
+++ b/custom_components/llmvision/const.py
@@ -32,6 +32,9 @@ CONF_AWS_REGION_NAME = "aws_region_name"
 # Custom OpenAI specific
 CONF_CUSTOM_OPENAI_ENDPOINT = "custom_openai_endpoint"
 
+# LiteLLM specific
+CONF_LITELLM_BASE_URL = "litellm_base_url"
+
 # Timeline
 CONF_RETENTION_TIME = "retention_time"
 
@@ -146,6 +149,7 @@ DEFAULT_CUSTOM_OPENAI_MODEL = "gpt-4o-mini"
 DEFAULT_AWS_MODEL = "us.amazon.nova-pro-v1:0"
 DEFAULT_OPENWEBUI_MODEL = "gemma3:4b"
 DEFAULT_OPENROUTER_MODEL = "google/gemma-3-4b-it:free"
+DEFAULT_LITELLM_MODEL = "gpt-4o-mini"
 
 DEFAULT_SUMMARY_PROMPT = "Provide a brief summary for the following titles. Focus on the key actions or changes that occurred over time and avoid unnecessary details or subjective interpretations. The summary should be concise, objective, and relevant to the content of the images. Keep the summary under 50 words and ensure it captures the main events or activities described in the descriptions. Here are the descriptions:\n "
 

--- a/custom_components/llmvision/manifest.json
+++ b/custom_components/llmvision/manifest.json
@@ -8,6 +8,6 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/valentinfrlch/ha-llmvision/issues",
-    "requirements": ["boto3==1.37.1", "aiosqlite==0.21.0", "aiofile==3.9.0"],
+    "requirements": ["boto3==1.37.1", "aiosqlite==0.21.0", "aiofile==3.9.0", "litellm>=1.80,<1.88"],
     "version": "1.7.0"
 }

--- a/custom_components/llmvision/providers.py
+++ b/custom_components/llmvision/providers.py
@@ -51,7 +51,6 @@ from .const import (
     DEFAULT_OPENWEBUI_MODEL,
     DEFAULT_OPENROUTER_MODEL,
     DEFAULT_LITELLM_MODEL,
-    CONF_LITELLM_BASE_URL,
     CONF_KEEP_ALIVE,
     CONF_CONTEXT_WINDOW,
     CONF_TEMPERATURE,
@@ -2048,6 +2047,105 @@ class AWSBedrock(Provider):
         return True
 
 
+class LiteLLM(Provider):
+
+    def __init__(self, hass: HomeAssistant, api_key: str, model: str):
+        super().__init__(hass, api_key, model)
+
+    async def _make_request(self, data: dict) -> str:
+        import litellm
+
+        kwargs = {
+            "model": data.pop("model"),
+            "messages": data.pop("messages"),
+            "drop_params": True,
+        }
+        kwargs.update(data)
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+
+        try:
+            response = await litellm.acompletion(**kwargs)
+        except Exception as e:
+            raise ServiceValidationError(f"LiteLLM error: {e}")
+
+        choices = getattr(response, "choices", None)
+        if not choices:
+            raise ServiceValidationError("empty_response")
+        message = choices[0].message
+        if message.content is None:
+            raise ServiceValidationError("invalid_response")
+        return message.content
+
+    def _prepare_vision_data(self, call: Any) -> dict:
+        default_parameters = self._get_default_parameters(call)
+        payload = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": []}],
+            "max_tokens": call.max_tokens,
+            "temperature": default_parameters.get("temperature"),
+            "top_p": default_parameters.get("top_p"),
+        }
+
+        for image, filename in zip(call.base64_images, call.filenames):
+            tag = (
+                ("Image " + str(call.base64_images.index(image) + 1))
+                if filename == ""
+                else filename
+            )
+            payload["messages"][0]["content"].append(
+                {"type": "text", "text": tag + ":"}
+            )
+            payload["messages"][0]["content"].append(
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:image/jpeg;base64,{image}"},
+                }
+            )
+
+        payload["messages"][0]["content"].append({"type": "text", "text": call.message})
+        system_prompt = self._get_system_prompt()
+        payload["messages"].insert(0, {"role": "system", "content": system_prompt})
+
+        if getattr(call, "use_memory", False):
+            memory_content = call.memory._get_memory_images(memory_type="OpenAI")
+            if memory_content:
+                payload["messages"].insert(
+                    1, {"role": "user", "content": memory_content}
+                )
+
+        return payload
+
+    def _prepare_text_data(self, call: Any) -> dict:
+        default_parameters = self._get_default_parameters(call)
+        title_prompt = self._get_title_prompt()
+        payload = {
+            "model": self.model,
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": title_prompt}]},
+                {"role": "user", "content": [{"type": "text", "text": call.message}]},
+            ],
+            "max_tokens": call.max_tokens,
+            "temperature": default_parameters.get("temperature"),
+            "top_p": default_parameters.get("top_p"),
+        }
+        return payload
+
+    async def validate(self) -> None | ServiceValidationError:
+        import litellm
+
+        try:
+            await litellm.acompletion(
+                model=self.model,
+                messages=[{"role": "user", "content": "Hi"}],
+                max_tokens=1,
+                drop_params=True,
+                api_key=self.api_key if self.api_key else None,
+            )
+        except Exception as e:
+            raise ServiceValidationError(f"handshake_failed: {e}")
+
+
 class ProviderFactory:
     """
     Factory to create provider instances from a provider name and config
@@ -2164,11 +2262,10 @@ class ProviderFactory:
             )
 
         if provider_name == "LiteLLM":
-            return OpenAI(
+            return LiteLLM(
                 hass,
                 api_key=cast(str, config.get(CONF_API_KEY) or ""),
                 model=model,
-                endpoint={"base_url": config.get(CONF_LITELLM_BASE_URL)},
             )
 
         raise ServiceValidationError("invalid_provider")

--- a/custom_components/llmvision/providers.py
+++ b/custom_components/llmvision/providers.py
@@ -50,6 +50,8 @@ from .const import (
     DEFAULT_AWS_MODEL,
     DEFAULT_OPENWEBUI_MODEL,
     DEFAULT_OPENROUTER_MODEL,
+    DEFAULT_LITELLM_MODEL,
+    CONF_LITELLM_BASE_URL,
     CONF_KEEP_ALIVE,
     CONF_CONTEXT_WINDOW,
     CONF_TEMPERATURE,
@@ -130,6 +132,7 @@ class Request:
             "AWS": DEFAULT_AWS_MODEL,  # For backwards compatibility
             "Open WebUI": DEFAULT_OPENWEBUI_MODEL,
             "OpenRouter": DEFAULT_OPENROUTER_MODEL,
+            "LiteLLM": DEFAULT_LITELLM_MODEL,
         }.get(provider_name)
 
     def validate(self, call: Any) -> None | ServiceValidationError:
@@ -2158,6 +2161,14 @@ class ProviderFactory:
                 api_key=cast(str, config.get(CONF_API_KEY) or ""),
                 model=model,
                 endpoint={"base_url": ENDPOINT_OPENROUTER},
+            )
+
+        if provider_name == "LiteLLM":
+            return OpenAI(
+                hass,
+                api_key=cast(str, config.get(CONF_API_KEY) or ""),
+                model=model,
+                endpoint={"base_url": config.get(CONF_LITELLM_BASE_URL)},
             )
 
         raise ServiceValidationError("invalid_provider")

--- a/custom_components/llmvision/providers.py
+++ b/custom_components/llmvision/providers.py
@@ -2052,20 +2052,51 @@ class LiteLLM(Provider):
     def __init__(self, hass: HomeAssistant, api_key: str, model: str):
         super().__init__(hass, api_key, model)
 
-    async def _make_request(self, data: dict) -> str:
-        import litellm
-
+    def _build_litellm_kwargs(self, data: dict) -> dict:
         kwargs = {
-            "model": data.pop("model"),
-            "messages": data.pop("messages"),
+            "model": data.get("model"),
+            "messages": data.get("messages"),
             "drop_params": True,
+            "timeout": self.request_timeout,
         }
-        kwargs.update(data)
+        for k in ("max_tokens", "temperature", "top_p"):
+            if k in data:
+                kwargs[k] = data[k]
         if self.api_key:
             kwargs["api_key"] = self.api_key
+        return kwargs
+
+    async def _make_request(self, data: dict) -> str:
+        import litellm
+        from litellm.exceptions import (
+            AuthenticationError,
+            BadRequestError,
+            ContextWindowExceededError,
+            NotFoundError,
+            RateLimitError,
+            Timeout,
+        )
+
+        kwargs = self._build_litellm_kwargs(data)
 
         try:
             response = await litellm.acompletion(**kwargs)
+        except AuthenticationError:
+            raise ServiceValidationError("invalid_api_key")
+        except NotFoundError:
+            raise ServiceValidationError(
+                f"Model '{self.model}' not found. Use LiteLLM format: openai/gpt-4o-mini, anthropic/claude-sonnet-4-6"
+            )
+        except ContextWindowExceededError:
+            raise ServiceValidationError("context_window_exceeded")
+        except RateLimitError:
+            raise ServiceValidationError("rate_limit")
+        except Timeout:
+            raise ServiceValidationError(
+                f"Request timed out after {self.request_timeout}s"
+            )
+        except BadRequestError as e:
+            raise ServiceValidationError(f"LiteLLM bad request: {e}")
         except Exception as e:
             raise ServiceValidationError(f"LiteLLM error: {e}")
 
@@ -2133,6 +2164,7 @@ class LiteLLM(Provider):
 
     async def validate(self) -> None | ServiceValidationError:
         import litellm
+        from litellm.exceptions import AuthenticationError, NotFoundError
 
         try:
             await litellm.acompletion(
@@ -2140,7 +2172,14 @@ class LiteLLM(Provider):
                 messages=[{"role": "user", "content": "Hi"}],
                 max_tokens=1,
                 drop_params=True,
+                timeout=self.request_timeout,
                 api_key=self.api_key if self.api_key else None,
+            )
+        except AuthenticationError:
+            raise ServiceValidationError("invalid_api_key")
+        except NotFoundError:
+            raise ServiceValidationError(
+                f"Model '{self.model}' not found. Use LiteLLM format: openai/gpt-4o-mini, anthropic/claude-sonnet-4-6"
             )
         except Exception as e:
             raise ServiceValidationError(f"handshake_failed: {e}")

--- a/custom_components/llmvision/strings.json
+++ b/custom_components/llmvision/strings.json
@@ -359,6 +359,38 @@
                     }
                 }
             },
+            "litellm": {
+                "title": "Configure LiteLLM",
+                "description": "LiteLLM is an AI gateway that provides access to 100+ LLM providers through a unified OpenAI-compatible API. Provide the base URL and API key of your LiteLLM proxy.",
+                "sections": {
+                    "connection_section": {
+                        "name": "Connection",
+                        "description": "LiteLLM proxy authentication",
+                        "data": {
+                            "litellm_base_url": "Base URL",
+                            "api_key": "API key"
+                        },
+                        "data_description": {
+                            "litellm_base_url": "The base URL of your LiteLLM proxy, e.g. http://localhost:4000/v1/chat/completions",
+                            "api_key": "Your LiteLLM proxy master key or virtual key."
+                        }
+                    },
+                    "model_section": {
+                        "name": "Model",
+                        "description": "Set default model parameters",
+                        "data": {
+                            "default_model": "Default model",
+                            "temperature": "Temperature",
+                            "top_p": "Top P"
+                        },
+                        "data_description": {
+                            "default_model": "The default model to use when no other model is specified. Use the LiteLLM model name format (e.g. openai/gpt-4o-mini, anthropic/claude-sonnet-4-6).",
+                            "temperature": "Controls the randomness of the output. Lower values make the output more deterministic.",
+                            "top_p": "Controls the diversity of the output. Lower values make the output more focused."
+                        }
+                    }
+                }
+            },
             "settings": {
                 "title": "Settings",
                 "description": "Configure the LLM Vision integration. This entry is required before setting up other providers. If you wish to use the default settings, just press 'Submit'.",

--- a/custom_components/llmvision/strings.json
+++ b/custom_components/llmvision/strings.json
@@ -361,18 +361,16 @@
             },
             "litellm": {
                 "title": "Configure LiteLLM",
-                "description": "LiteLLM is an AI gateway that provides access to 100+ LLM providers through a unified OpenAI-compatible API. Provide the base URL and API key of your LiteLLM proxy.",
+                "description": "LiteLLM provides access to 100+ LLM providers (OpenAI, Anthropic, Google, AWS Bedrock, Ollama, etc.) through a unified SDK. Use the provider-prefixed model format.",
                 "sections": {
                     "connection_section": {
                         "name": "Connection",
-                        "description": "LiteLLM proxy authentication",
+                        "description": "API key for your LLM provider",
                         "data": {
-                            "litellm_base_url": "Base URL",
                             "api_key": "API key"
                         },
                         "data_description": {
-                            "litellm_base_url": "The base URL of your LiteLLM proxy, e.g. http://localhost:4000/v1/chat/completions",
-                            "api_key": "Your LiteLLM proxy master key or virtual key."
+                            "api_key": "Your LLM provider API key (e.g. OpenAI, Anthropic, Google). LiteLLM routes to the correct provider based on the model name."
                         }
                     },
                     "model_section": {
@@ -384,7 +382,7 @@
                             "top_p": "Top P"
                         },
                         "data_description": {
-                            "default_model": "The default model to use when no other model is specified. Use the LiteLLM model name format (e.g. openai/gpt-4o-mini, anthropic/claude-sonnet-4-6).",
+                            "default_model": "Use the LiteLLM model format: openai/gpt-4o-mini, anthropic/claude-sonnet-4-6, gemini/gemini-2.0-flash, etc.",
                             "temperature": "Controls the randomness of the output. Lower values make the output more deterministic.",
                             "top_p": "Controls the diversity of the output. Lower values make the output more focused."
                         }

--- a/custom_components/llmvision/translations/en.json
+++ b/custom_components/llmvision/translations/en.json
@@ -359,6 +359,38 @@
                     }
                 }
             },
+            "litellm": {
+                "title": "Configure LiteLLM",
+                "description": "LiteLLM is an AI gateway that provides access to 100+ LLM providers through a unified OpenAI-compatible API. Provide the base URL and API key of your LiteLLM proxy.",
+                "sections": {
+                    "connection_section": {
+                        "name": "Connection",
+                        "description": "LiteLLM proxy authentication",
+                        "data": {
+                            "litellm_base_url": "Base URL",
+                            "api_key": "API key"
+                        },
+                        "data_description": {
+                            "litellm_base_url": "The base URL of your LiteLLM proxy, e.g. http://localhost:4000/v1/chat/completions",
+                            "api_key": "Your LiteLLM proxy master key or virtual key."
+                        }
+                    },
+                    "model_section": {
+                        "name": "Model",
+                        "description": "Set default model parameters",
+                        "data": {
+                            "default_model": "Default model",
+                            "temperature": "Temperature",
+                            "top_p": "Top P"
+                        },
+                        "data_description": {
+                            "default_model": "The default model to use when no other model is specified. Use the LiteLLM model name format (e.g. openai/gpt-4o-mini, anthropic/claude-sonnet-4-6).",
+                            "temperature": "Controls the randomness of the output. Lower values make the output more deterministic.",
+                            "top_p": "Controls the diversity of the output. Lower values make the output more focused."
+                        }
+                    }
+                }
+            },
             "settings": {
                 "title": "Settings",
                 "description": "Configure the LLM Vision integration. This entry is required before setting up other providers. If you wish to use the default settings, just press 'Submit'.",

--- a/custom_components/llmvision/translations/en.json
+++ b/custom_components/llmvision/translations/en.json
@@ -361,18 +361,16 @@
             },
             "litellm": {
                 "title": "Configure LiteLLM",
-                "description": "LiteLLM is an AI gateway that provides access to 100+ LLM providers through a unified OpenAI-compatible API. Provide the base URL and API key of your LiteLLM proxy.",
+                "description": "LiteLLM provides access to 100+ LLM providers (OpenAI, Anthropic, Google, AWS Bedrock, Ollama, etc.) through a unified SDK. Use the provider-prefixed model format.",
                 "sections": {
                     "connection_section": {
                         "name": "Connection",
-                        "description": "LiteLLM proxy authentication",
+                        "description": "API key for your LLM provider",
                         "data": {
-                            "litellm_base_url": "Base URL",
                             "api_key": "API key"
                         },
                         "data_description": {
-                            "litellm_base_url": "The base URL of your LiteLLM proxy, e.g. http://localhost:4000/v1/chat/completions",
-                            "api_key": "Your LiteLLM proxy master key or virtual key."
+                            "api_key": "Your LLM provider API key (e.g. OpenAI, Anthropic, Google). LiteLLM routes to the correct provider based on the model name."
                         }
                     },
                     "model_section": {
@@ -384,7 +382,7 @@
                             "top_p": "Top P"
                         },
                         "data_description": {
-                            "default_model": "The default model to use when no other model is specified. Use the LiteLLM model name format (e.g. openai/gpt-4o-mini, anthropic/claude-sonnet-4-6).",
+                            "default_model": "Use the LiteLLM model format: openai/gpt-4o-mini, anthropic/claude-sonnet-4-6, gemini/gemini-2.0-flash, etc.",
                             "temperature": "Controls the randomness of the output. Lower values make the output more deterministic.",
                             "top_p": "Controls the diversity of the output. Lower values make the output more focused."
                         }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -37,6 +37,8 @@ from custom_components.llmvision.const import (
     CONF_TITLE_PROMPT,
     CONF_TOP_P,
     DEFAULT_OPENAI_MODEL,
+    DEFAULT_LITELLM_MODEL,
+    CONF_LITELLM_BASE_URL,
     ENDPOINT_AZURE,
     ENDPOINT_OPENROUTER,
     ENDPOINT_OPENWEBUI,
@@ -346,6 +348,7 @@ class TestProviderSteps:
             ("ollama", "Ollama"),
             ("openwebui", "OpenWebUI"),
             ("openrouter", "OpenRouter"),
+            ("litellm", "LiteLLM"),
         ],
     )
     async def test_provider_steps_show_form_without_input(
@@ -749,6 +752,34 @@ class TestProviderSteps:
                 ),
                 "handshake_failed",
             ),
+            (
+                "litellm",
+                "LiteLLM",
+                "custom_components.llmvision.config_flow.OpenAI",
+                {
+                    "connection_section": {
+                        CONF_API_KEY: "secret",
+                        CONF_LITELLM_BASE_URL: "http://localhost:4000/v1/chat/completions",
+                    },
+                    "model_section": {
+                        CONF_DEFAULT_MODEL: "openai/gpt-4o-mini",
+                        CONF_TEMPERATURE: 0.5,
+                        CONF_TOP_P: 0.9,
+                    },
+                },
+                "LiteLLM",
+                lambda flow: (
+                    (flow.hass,),
+                    {
+                        "api_key": "secret",
+                        "model": "openai/gpt-4o-mini",
+                        "endpoint": {
+                            "base_url": "http://localhost:4000/v1/chat/completions"
+                        },
+                    },
+                ),
+                "handshake_failed",
+            ),
         ],
     )
     async def test_provider_steps_create_entries_after_successful_validation(
@@ -889,6 +920,23 @@ class TestProviderSteps:
                         CONF_TEMPERATURE: 0.5,
                         CONF_TOP_P: 0.9,
                         CONF_REASONING_EFFORT: "none",
+                    },
+                },
+                "handshake_failed",
+            ),
+            (
+                "litellm",
+                "LiteLLM",
+                "custom_components.llmvision.config_flow.OpenAI",
+                {
+                    "connection_section": {
+                        CONF_API_KEY: "secret",
+                        CONF_LITELLM_BASE_URL: "http://localhost:4000/v1/chat/completions",
+                    },
+                    "model_section": {
+                        CONF_DEFAULT_MODEL: "openai/gpt-4o-mini",
+                        CONF_TEMPERATURE: 0.5,
+                        CONF_TOP_P: 0.9,
                     },
                 },
                 "handshake_failed",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -38,7 +38,6 @@ from custom_components.llmvision.const import (
     CONF_TOP_P,
     DEFAULT_OPENAI_MODEL,
     DEFAULT_LITELLM_MODEL,
-    CONF_LITELLM_BASE_URL,
     ENDPOINT_AZURE,
     ENDPOINT_OPENROUTER,
     ENDPOINT_OPENWEBUI,
@@ -755,11 +754,10 @@ class TestProviderSteps:
             (
                 "litellm",
                 "LiteLLM",
-                "custom_components.llmvision.config_flow.OpenAI",
+                "custom_components.llmvision.config_flow.LiteLLM",
                 {
                     "connection_section": {
                         CONF_API_KEY: "secret",
-                        CONF_LITELLM_BASE_URL: "http://localhost:4000/v1/chat/completions",
                     },
                     "model_section": {
                         CONF_DEFAULT_MODEL: "openai/gpt-4o-mini",
@@ -773,9 +771,6 @@ class TestProviderSteps:
                     {
                         "api_key": "secret",
                         "model": "openai/gpt-4o-mini",
-                        "endpoint": {
-                            "base_url": "http://localhost:4000/v1/chat/completions"
-                        },
                     },
                 ),
                 "handshake_failed",
@@ -927,11 +922,10 @@ class TestProviderSteps:
             (
                 "litellm",
                 "LiteLLM",
-                "custom_components.llmvision.config_flow.OpenAI",
+                "custom_components.llmvision.config_flow.LiteLLM",
                 {
                     "connection_section": {
                         CONF_API_KEY: "secret",
-                        CONF_LITELLM_BASE_URL: "http://localhost:4000/v1/chat/completions",
                     },
                     "model_section": {
                         CONF_DEFAULT_MODEL: "openai/gpt-4o-mini",

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -52,6 +52,8 @@ from custom_components.llmvision.const import (
     DEFAULT_OLLAMA_MODEL,
     DEFAULT_SYSTEM_PROMPT,
     DEFAULT_TITLE_PROMPT,
+    DEFAULT_LITELLM_MODEL,
+    CONF_LITELLM_BASE_URL,
 )
 
 
@@ -209,6 +211,16 @@ class TestRequest:
             result = request.get_default_model("test_provider")
 
             assert result == DEFAULT_ANTHROPIC_MODEL
+
+    def test_get_default_model_fallback_litellm(self, mock_hass):
+        """Test get_default_model fallback to LiteLLM default."""
+        mock_hass.data = {DOMAIN: {"test_provider": {CONF_PROVIDER: "LiteLLM"}}}
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            request = Request(mock_hass, "test", 1000, 0.5)
+
+            result = request.get_default_model("test_provider")
+
+            assert result == DEFAULT_LITELLM_MODEL
 
     def test_get_default_model_invalid_provider(self, mock_hass):
         """Test get_default_model with invalid provider."""
@@ -1129,6 +1141,20 @@ class TestProviderFactory:
 
             assert isinstance(provider, OpenAI)
 
+    def test_create_litellm(self, mock_hass):
+        """Test ProviderFactory creates LiteLLM provider."""
+        config = {
+            CONF_API_KEY: "test_key",
+            CONF_LITELLM_BASE_URL: "http://localhost:4000/v1/chat/completions",
+        }
+
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            provider = ProviderFactory.create(
+                mock_hass, "LiteLLM", config, "openai/gpt-4o-mini"
+            )
+
+            assert isinstance(provider, OpenAI)
+
 
 @pytest.fixture
 def coverage_hass(monkeypatch):
@@ -1562,6 +1588,10 @@ async def test_provider_coverage_misc_paths(monkeypatch, coverage_hass):
     )
     assert isinstance(
         ProviderFactory.create(coverage_hass, "OpenWebUI", config, "m"), OpenAI
+    )
+    config[CONF_LITELLM_BASE_URL] = "http://localhost:4000/v1/chat/completions"
+    assert isinstance(
+        ProviderFactory.create(coverage_hass, "LiteLLM", config, "m"), OpenAI
     )
     with pytest.raises(ServiceValidationError):
         ProviderFactory.create(coverage_hass, "Nope", config, "m")

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1024,6 +1024,423 @@ class TestAWSBedrock:
             assert headers["Content-type"] == "application/json"
 
 
+class TestLiteLLM:
+    """Test LiteLLM provider class."""
+
+    def test_init(self, mock_hass):
+        """Test LiteLLM initialization."""
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            provider = LiteLLM(mock_hass, "sk-test", "anthropic/claude-sonnet-4-6")
+
+            assert provider.api_key == "sk-test"
+            assert provider.model == "anthropic/claude-sonnet-4-6"
+
+    def test_init_empty_api_key(self, mock_hass):
+        """Test LiteLLM with empty API key (env var fallback)."""
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            provider = LiteLLM(mock_hass, "", "openai/gpt-4o-mini")
+
+            assert provider.api_key == ""
+
+    def test_build_litellm_kwargs_includes_drop_params(self, mock_hass):
+        """Test that drop_params=True is always set."""
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            provider = LiteLLM(mock_hass, "sk-test", "openai/gpt-4o-mini")
+            data = {
+                "model": "openai/gpt-4o-mini",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 100,
+                "temperature": 0.5,
+                "top_p": 0.9,
+            }
+            kwargs = provider._build_litellm_kwargs(data)
+
+            assert kwargs["drop_params"] is True
+            assert kwargs["api_key"] == "sk-test"
+            assert kwargs["model"] == "openai/gpt-4o-mini"
+            assert kwargs["timeout"] == provider.request_timeout
+
+    def test_build_litellm_kwargs_no_api_key_when_empty(self, mock_hass):
+        """Test that empty api_key is not passed to litellm."""
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            provider = LiteLLM(mock_hass, "", "openai/gpt-4o-mini")
+            data = {
+                "model": "openai/gpt-4o-mini",
+                "messages": [{"role": "user", "content": "hi"}],
+            }
+            kwargs = provider._build_litellm_kwargs(data)
+
+            assert "api_key" not in kwargs
+
+    def test_build_litellm_kwargs_does_not_mutate_input(self, mock_hass):
+        """Test that _build_litellm_kwargs does not modify the input dict."""
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            provider = LiteLLM(mock_hass, "sk-test", "openai/gpt-4o-mini")
+            data = {
+                "model": "openai/gpt-4o-mini",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 100,
+            }
+            original_data = data.copy()
+            provider._build_litellm_kwargs(data)
+
+            assert data == original_data
+
+    @pytest.mark.asyncio
+    async def test_make_request_success(self, mock_hass):
+        """Test successful completion call."""
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            provider = LiteLLM(mock_hass, "sk-test", "openai/gpt-4o-mini")
+
+        mock_response = Mock()
+        mock_response.choices = [Mock(message=Mock(content="Hello world"))]
+
+        with patch("litellm.acompletion", new_callable=AsyncMock, return_value=mock_response):
+            result = await provider._make_request({
+                "model": "openai/gpt-4o-mini",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 100,
+            })
+            assert result == "Hello world"
+
+    @pytest.mark.asyncio
+    async def test_make_request_auth_error(self, mock_hass):
+        """Test invalid/expired API key raises specific error."""
+        from litellm.exceptions import AuthenticationError
+
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            provider = LiteLLM(mock_hass, "sk-invalid", "openai/gpt-4o-mini")
+
+        with patch(
+            "litellm.acompletion",
+            new_callable=AsyncMock,
+            side_effect=AuthenticationError(
+                message="Invalid API key",
+                model="openai/gpt-4o-mini",
+                llm_provider="openai",
+            ),
+        ):
+            with pytest.raises(ServiceValidationError, match="invalid_api_key"):
+                await provider._make_request({
+                    "model": "openai/gpt-4o-mini",
+                    "messages": [{"role": "user", "content": "hi"}],
+                })
+
+    @pytest.mark.asyncio
+    async def test_make_request_model_not_found(self, mock_hass):
+        """Test unsupported model raises specific error."""
+        from litellm.exceptions import NotFoundError
+
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            provider = LiteLLM(mock_hass, "sk-test", "fake/nonexistent-model")
+
+        with patch(
+            "litellm.acompletion",
+            new_callable=AsyncMock,
+            side_effect=NotFoundError(
+                message="Model not found",
+                model="fake/nonexistent-model",
+                llm_provider="fake",
+            ),
+        ):
+            with pytest.raises(ServiceValidationError, match="not found"):
+                await provider._make_request({
+                    "model": "fake/nonexistent-model",
+                    "messages": [{"role": "user", "content": "hi"}],
+                })
+
+    @pytest.mark.asyncio
+    async def test_make_request_rate_limit(self, mock_hass):
+        """Test 429 rate limit raises specific error."""
+        from litellm.exceptions import RateLimitError
+
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            provider = LiteLLM(mock_hass, "sk-test", "openai/gpt-4o-mini")
+
+        with patch(
+            "litellm.acompletion",
+            new_callable=AsyncMock,
+            side_effect=RateLimitError(
+                message="Rate limit exceeded",
+                model="openai/gpt-4o-mini",
+                llm_provider="openai",
+            ),
+        ):
+            with pytest.raises(ServiceValidationError, match="rate_limit"):
+                await provider._make_request({
+                    "model": "openai/gpt-4o-mini",
+                    "messages": [{"role": "user", "content": "hi"}],
+                })
+
+    @pytest.mark.asyncio
+    async def test_make_request_context_window_exceeded(self, mock_hass):
+        """Test token limit exceeded raises specific error."""
+        from litellm.exceptions import ContextWindowExceededError
+
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            provider = LiteLLM(mock_hass, "sk-test", "openai/gpt-4o-mini")
+
+        with patch(
+            "litellm.acompletion",
+            new_callable=AsyncMock,
+            side_effect=ContextWindowExceededError(
+                message="Context window exceeded",
+                model="openai/gpt-4o-mini",
+                llm_provider="openai",
+            ),
+        ):
+            with pytest.raises(ServiceValidationError, match="context_window"):
+                await provider._make_request({
+                    "model": "openai/gpt-4o-mini",
+                    "messages": [{"role": "user", "content": "x" * 100000}],
+                })
+
+    @pytest.mark.asyncio
+    async def test_make_request_timeout(self, mock_hass):
+        """Test timeout raises specific error."""
+        from litellm.exceptions import Timeout
+
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            provider = LiteLLM(mock_hass, "sk-test", "openai/gpt-4o-mini")
+
+        with patch(
+            "litellm.acompletion",
+            new_callable=AsyncMock,
+            side_effect=Timeout(
+                message="Request timed out",
+                model="openai/gpt-4o-mini",
+                llm_provider="openai",
+            ),
+        ):
+            with pytest.raises(ServiceValidationError, match="timed out"):
+                await provider._make_request({
+                    "model": "openai/gpt-4o-mini",
+                    "messages": [{"role": "user", "content": "hi"}],
+                })
+
+    @pytest.mark.asyncio
+    async def test_make_request_bad_request(self, mock_hass):
+        """Test 400 bad request raises specific error."""
+        from litellm.exceptions import BadRequestError
+
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            provider = LiteLLM(mock_hass, "sk-test", "openai/gpt-4o-mini")
+
+        with patch(
+            "litellm.acompletion",
+            new_callable=AsyncMock,
+            side_effect=BadRequestError(
+                message="Invalid request",
+                model="openai/gpt-4o-mini",
+                llm_provider="openai",
+            ),
+        ):
+            with pytest.raises(ServiceValidationError, match="bad request"):
+                await provider._make_request({
+                    "model": "openai/gpt-4o-mini",
+                    "messages": [{"role": "user", "content": "hi"}],
+                })
+
+    @pytest.mark.asyncio
+    async def test_make_request_empty_choices(self, mock_hass):
+        """Test empty choices in response raises error."""
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            provider = LiteLLM(mock_hass, "sk-test", "openai/gpt-4o-mini")
+
+        mock_response = Mock()
+        mock_response.choices = []
+
+        with patch("litellm.acompletion", new_callable=AsyncMock, return_value=mock_response):
+            with pytest.raises(ServiceValidationError, match="empty_response"):
+                await provider._make_request({
+                    "model": "openai/gpt-4o-mini",
+                    "messages": [{"role": "user", "content": "hi"}],
+                })
+
+    @pytest.mark.asyncio
+    async def test_make_request_null_content(self, mock_hass):
+        """Test null content in response raises error."""
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            provider = LiteLLM(mock_hass, "sk-test", "openai/gpt-4o-mini")
+
+        mock_response = Mock()
+        mock_response.choices = [Mock(message=Mock(content=None))]
+
+        with patch("litellm.acompletion", new_callable=AsyncMock, return_value=mock_response):
+            with pytest.raises(ServiceValidationError, match="invalid_response"):
+                await provider._make_request({
+                    "model": "openai/gpt-4o-mini",
+                    "messages": [{"role": "user", "content": "hi"}],
+                })
+
+    @pytest.mark.asyncio
+    async def test_make_request_no_choices_attr(self, mock_hass):
+        """Test malformed response object with no choices attribute."""
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            provider = LiteLLM(mock_hass, "sk-test", "openai/gpt-4o-mini")
+
+        mock_response = object()
+
+        with patch("litellm.acompletion", new_callable=AsyncMock, return_value=mock_response):
+            with pytest.raises(ServiceValidationError, match="empty_response"):
+                await provider._make_request({
+                    "model": "openai/gpt-4o-mini",
+                    "messages": [{"role": "user", "content": "hi"}],
+                })
+
+    def test_prepare_vision_data(self, mock_hass, mock_call):
+        """Test vision data preparation builds correct OpenAI-format payload."""
+        mock_hass.data = {
+            DOMAIN: {
+                "test_provider": {
+                    CONF_PROVIDER: "Settings",
+                    "system_prompt": "You are helpful.",
+                    "title_prompt": "Title this.",
+                },
+            }
+        }
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            provider = LiteLLM(mock_hass, "sk-test", "anthropic/claude-sonnet-4-6")
+
+        data = provider._prepare_vision_data(mock_call)
+
+        assert data["model"] == "anthropic/claude-sonnet-4-6"
+        assert data["max_tokens"] == 1000
+        assert data["messages"][0]["role"] == "system"
+        user_content = data["messages"][1]["content"]
+        assert any(item.get("type") == "image_url" for item in user_content)
+        assert any(item.get("type") == "text" and "Test message" in item["text"] for item in user_content)
+
+    def test_prepare_text_data(self, mock_hass, mock_call):
+        """Test text data preparation builds correct payload."""
+        mock_hass.data = {
+            DOMAIN: {
+                "test_provider": {
+                    CONF_PROVIDER: "Settings",
+                    "system_prompt": "You are helpful.",
+                    "title_prompt": "Summarize this.",
+                },
+            }
+        }
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            provider = LiteLLM(mock_hass, "sk-test", "openai/gpt-4o-mini")
+
+        data = provider._prepare_text_data(mock_call)
+
+        assert data["model"] == "openai/gpt-4o-mini"
+        assert len(data["messages"]) == 2
+        assert data["messages"][0]["role"] == "user"
+        assert data["messages"][1]["role"] == "user"
+
+    @pytest.mark.asyncio
+    async def test_validate_success(self, mock_hass):
+        """Test successful validation."""
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            provider = LiteLLM(mock_hass, "sk-test", "openai/gpt-4o-mini")
+
+        mock_response = Mock()
+        mock_response.choices = [Mock(message=Mock(content="Hi"))]
+
+        with patch("litellm.acompletion", new_callable=AsyncMock, return_value=mock_response):
+            await provider.validate()
+
+    @pytest.mark.asyncio
+    async def test_validate_auth_error(self, mock_hass):
+        """Test validation with invalid API key."""
+        from litellm.exceptions import AuthenticationError
+
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            provider = LiteLLM(mock_hass, "sk-invalid", "openai/gpt-4o-mini")
+
+        with patch(
+            "litellm.acompletion",
+            new_callable=AsyncMock,
+            side_effect=AuthenticationError(
+                message="Invalid key",
+                model="openai/gpt-4o-mini",
+                llm_provider="openai",
+            ),
+        ):
+            with pytest.raises(ServiceValidationError, match="invalid_api_key"):
+                await provider.validate()
+
+    @pytest.mark.asyncio
+    async def test_validate_model_not_found(self, mock_hass):
+        """Test validation with bad model name."""
+        from litellm.exceptions import NotFoundError
+
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            provider = LiteLLM(mock_hass, "sk-test", "bad/model")
+
+        with patch(
+            "litellm.acompletion",
+            new_callable=AsyncMock,
+            side_effect=NotFoundError(
+                message="Not found",
+                model="bad/model",
+                llm_provider="bad",
+            ),
+        ):
+            with pytest.raises(ServiceValidationError, match="not found"):
+                await provider.validate()
+
+    @pytest.mark.asyncio
+    async def test_validate_generic_error_falls_through(self, mock_hass):
+        """Test validation with unexpected error."""
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            provider = LiteLLM(mock_hass, "sk-test", "openai/gpt-4o-mini")
+
+        with patch(
+            "litellm.acompletion",
+            new_callable=AsyncMock,
+            side_effect=ConnectionError("network down"),
+        ):
+            with pytest.raises(ServiceValidationError, match="handshake_failed"):
+                await provider.validate()
+
+    @pytest.mark.asyncio
+    async def test_make_request_passes_timeout(self, mock_hass):
+        """Test that timeout from settings is passed to litellm."""
+        mock_hass.data = {
+            DOMAIN: {
+                "settings_entry": {
+                    CONF_PROVIDER: "Settings",
+                    "request_timeout": 120,
+                },
+            }
+        }
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            provider = LiteLLM(mock_hass, "sk-test", "openai/gpt-4o-mini")
+
+        mock_response = Mock()
+        mock_response.choices = [Mock(message=Mock(content="ok"))]
+
+        with patch("litellm.acompletion", new_callable=AsyncMock, return_value=mock_response) as mock_call:
+            await provider._make_request({
+                "model": "openai/gpt-4o-mini",
+                "messages": [{"role": "user", "content": "hi"}],
+            })
+            call_kwargs = mock_call.call_args[1]
+            assert "timeout" in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_make_request_provider_prefixed_model(self, mock_hass):
+        """Test that provider-prefixed model strings pass through correctly."""
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            provider = LiteLLM(mock_hass, "sk-test", "anthropic/claude-sonnet-4-6")
+
+        mock_response = Mock()
+        mock_response.choices = [Mock(message=Mock(content="ok"))]
+
+        with patch("litellm.acompletion", new_callable=AsyncMock, return_value=mock_response) as mock_call:
+            await provider._make_request({
+                "model": "anthropic/claude-sonnet-4-6",
+                "messages": [{"role": "user", "content": "hi"}],
+            })
+            call_kwargs = mock_call.call_args[1]
+            assert call_kwargs["model"] == "anthropic/claude-sonnet-4-6"
+
+
 class TestProviderFactory:
     """Test ProviderFactory class."""
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -17,6 +17,7 @@ from custom_components.llmvision.providers import (
     LocalAI,
     Ollama,
     AWSBedrock,
+    LiteLLM,
     ProviderFactory,
 )
 from custom_components.llmvision.const import (
@@ -53,7 +54,6 @@ from custom_components.llmvision.const import (
     DEFAULT_SYSTEM_PROMPT,
     DEFAULT_TITLE_PROMPT,
     DEFAULT_LITELLM_MODEL,
-    CONF_LITELLM_BASE_URL,
 )
 
 
@@ -1145,7 +1145,6 @@ class TestProviderFactory:
         """Test ProviderFactory creates LiteLLM provider."""
         config = {
             CONF_API_KEY: "test_key",
-            CONF_LITELLM_BASE_URL: "http://localhost:4000/v1/chat/completions",
         }
 
         with patch("custom_components.llmvision.providers.async_get_clientsession"):
@@ -1153,7 +1152,7 @@ class TestProviderFactory:
                 mock_hass, "LiteLLM", config, "openai/gpt-4o-mini"
             )
 
-            assert isinstance(provider, OpenAI)
+            assert isinstance(provider, LiteLLM)
 
 
 @pytest.fixture
@@ -1589,9 +1588,8 @@ async def test_provider_coverage_misc_paths(monkeypatch, coverage_hass):
     assert isinstance(
         ProviderFactory.create(coverage_hass, "OpenWebUI", config, "m"), OpenAI
     )
-    config[CONF_LITELLM_BASE_URL] = "http://localhost:4000/v1/chat/completions"
     assert isinstance(
-        ProviderFactory.create(coverage_hass, "LiteLLM", config, "m"), OpenAI
+        ProviderFactory.create(coverage_hass, "LiteLLM", config, "m"), LiteLLM
     )
     with pytest.raises(ServiceValidationError):
         ProviderFactory.create(coverage_hass, "Nope", config, "m")


### PR DESCRIPTION
Add [LiteLLM](https://github.com/BerriAI/litellm) as a native provider using the LiteLLM Python SDK (`litellm.acompletion`), giving ha-llmvision access to 100+ LLM providers (Anthropic, Google, AWS Bedrock, Groq, Ollama, etc.) without requiring a separate proxy deployment.

Users set their provider's API key and use LiteLLM's model format (e.g. `anthropic/claude-sonnet-4-6`, `gemini/gemini-2.0-flash`). LiteLLM routes to the correct provider and translates the request format automatically. `drop_params=True` handles per-provider parameter differences.

**Changes:**

- New `LiteLLM(Provider)` class in `providers.py` using `litellm.acompletion()` for both vision and text requests
- Specific exception handling for `AuthenticationError`, `NotFoundError`, `RateLimitError`, `ContextWindowExceededError`, `Timeout`, and `BadRequestError` from `litellm.exceptions`
- Timeout from HA settings (`request_timeout`) passed through to litellm SDK calls
- Config flow matching Groq's pattern (API key + model + temperature/top_p, no proxy URL needed)
- `litellm>=1.80,<1.88` added to `manifest.json` requirements
- 23 unit tests covering: init, kwargs building, successful completion, auth error, model not found, rate limit, context window exceeded, timeout, bad request, empty choices, null content, malformed response, vision data prep, text data prep, validate success/failure, timeout passthrough, model string format

**Usage:**

1. In HA, add LLM Vision integration, select "LiteLLM"
2. Enter your provider API key (e.g. Anthropic key, Google key)
3. Set model in LiteLLM format: `anthropic/claude-sonnet-4-6`, `openai/gpt-4o-mini`, `gemini/gemini-2.0-flash`

No proxy server needed - LiteLLM SDK handles provider routing directly.

```python
import litellm
response = litellm.completion(
    model="anthropic/claude-sonnet-4-6",
    messages=[{"role": "user", "content": "Describe this image"}],
)
print(response.choices[0].message.content)
```
