### PR TITLE
Add Requesty provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 </p>
 
 ## Features
-- Supports OpenRouter, OpenAI, Anthropic, Google Gemini, AWS Bedrock, Azure, Groq, [Ollama](https://ollama.com/), [Open WebUI](https://github.com/open-webui/open-webui), [LocalAI](https://github.com/mudler/LocalAI) and any provider with OpenAI compatible endpoints.
+- Supports OpenRouter, [Requesty](https://requesty.ai) (an OpenAI-compatible router), OpenAI, Anthropic, Google Gemini, AWS Bedrock, Azure, Groq, [Ollama](https://ollama.com/), [Open WebUI](https://github.com/open-webui/open-webui), [LocalAI](https://github.com/mudler/LocalAI) and any provider with OpenAI compatible endpoints.
 - Answers questions and provides descriptions of images, video files, live camera feeds, and Frigate events based on your prompt.
 - Remembers people, pets and objects
 - Keeps a timeline of camera events, so you can display them on your dashboard or ask Assist about them.

--- a/custom_components/llmvision/config_flow.py
+++ b/custom_components/llmvision/config_flow.py
@@ -56,9 +56,11 @@ from .const import (
     DEFAULT_OPENWEBUI_MODEL,
     DEFAULT_OPENROUTER_MODEL,
     DEFAULT_MISTRAL_MODEL,
+    DEFAULT_REQUESTY_MODEL,
     ENDPOINT_OPENWEBUI,
     ENDPOINT_AZURE,
     ENDPOINT_OPENROUTER,
+    ENDPOINT_REQUESTY,
     CONF_CONTEXT_WINDOW,
     CONF_THINKING_BUDGET,
     CONF_THINK,
@@ -91,6 +93,7 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             "OpenRouter": self.async_step_openrouter,
             # TODO: Enable in next minor release (1.8.0).
             # "Mistral": self.async_step_mistral,
+            "Requesty": self.async_step_requesty,
         }
 
         step_method = provider_steps.get(provider)
@@ -131,6 +134,7 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                                 "OpenRouter",
                                 # TODO: Enable in next minor release (1.8.0).
                                 # "Mistral",
+                                "Requesty",
                                 "Custom OpenAI",
                             ],
                             "mode": "dropdown",
@@ -1760,6 +1764,128 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="mistral",
+            data_schema=data_schema,
+        )
+
+    async def async_step_requesty(self, user_input=None):
+        data_schema = vol.Schema(
+            {
+                vol.Optional("connection_section"): section(
+                    vol.Schema(
+                        {
+                            vol.Required(CONF_API_KEY): selector(
+                                {"text": {"type": "password"}}
+                            ),
+                        }
+                    ),
+                    {"collapsed": False},
+                ),
+                vol.Optional("model_section"): section(
+                    vol.Schema(
+                        {
+                            vol.Required(
+                                CONF_DEFAULT_MODEL, default=DEFAULT_REQUESTY_MODEL
+                            ): str,
+                            vol.Optional(CONF_TEMPERATURE, default=0.5): selector(
+                                {
+                                    "number": {
+                                        "min": 0,
+                                        "max": 1,
+                                        "step": 0.1,
+                                        "mode": "slider",
+                                    }
+                                }
+                            ),
+                            vol.Optional(CONF_TOP_P, default=0.9): selector(
+                                {
+                                    "number": {
+                                        "min": 0,
+                                        "max": 1,
+                                        "step": 0.1,
+                                        "mode": "slider",
+                                    }
+                                }
+                            ),
+                            vol.Optional(
+                                CONF_REASONING_EFFORT, default="none"
+                            ): selector(
+                                {
+                                    "select": {
+                                        "options": [
+                                            {"label": "None", "value": "none"},
+                                            {"label": "Minimal", "value": "minimal"},
+                                            {"label": "Low", "value": "low"},
+                                            {"label": "Medium", "value": "medium"},
+                                            {"label": "High", "value": "high"},
+                                            {"label": "Extra High", "value": "xhigh"},
+                                        ]
+                                    }
+                                }
+                            ),
+                        }
+                    ),
+                    {"collapsed": False},
+                ),
+            }
+        )
+
+        if self.source == config_entries.SOURCE_RECONFIGURE:
+            # load existing configuration and add it to the dialog
+            self.init_info = self._get_reconfigure_entry().data
+            # Re-nest the flat config entry data into sections
+            suggested = {
+                "connection_section": {
+                    CONF_API_KEY: self.init_info.get(CONF_API_KEY),
+                },
+                "model_section": {
+                    CONF_DEFAULT_MODEL: self.init_info.get(
+                        CONF_DEFAULT_MODEL, DEFAULT_REQUESTY_MODEL
+                    ),
+                    CONF_TEMPERATURE: self.init_info.get(CONF_TEMPERATURE, 0.5),
+                    CONF_TOP_P: self.init_info.get(CONF_TOP_P, 0.9),
+                    CONF_REASONING_EFFORT: self.init_info.get(
+                        CONF_REASONING_EFFORT, "none"
+                    ),
+                },
+            }
+            data_schema = self.add_suggested_values_to_schema(data_schema, suggested)
+
+        if user_input is not None:
+            # save provider to user_input
+            user_input[CONF_PROVIDER] = self.init_info[CONF_PROVIDER]
+            # flatten dict to remove nested keys
+            user_input = flatten_dict(user_input)
+            try:
+                requesty = OpenAI(
+                    self.hass,
+                    api_key=user_input[CONF_API_KEY],
+                    model=user_input[CONF_DEFAULT_MODEL],
+                    endpoint={
+                        "base_url": ENDPOINT_REQUESTY,
+                    },
+                )
+                await requesty.validate()
+                # add the mode to user_input
+                user_input[CONF_PROVIDER] = self.init_info[CONF_PROVIDER]
+                if self.source == config_entries.SOURCE_RECONFIGURE:
+                    # we're reconfiguring an existing config
+                    return self.async_update_reload_and_abort(
+                        self._get_reconfigure_entry(),
+                        data_updates=user_input,
+                    )
+                else:
+                    # New config entry
+                    return self.async_create_entry(title="Requesty", data=user_input)
+            except ServiceValidationError as e:
+                _LOGGER.error(f"Validation failed: {e}")
+                return self.async_show_form(
+                    step_id="requesty",
+                    data_schema=data_schema,
+                    errors={"base": "handshake_failed"},
+                )
+
+        return self.async_show_form(
+            step_id="requesty",
             data_schema=data_schema,
         )
 

--- a/custom_components/llmvision/const.py
+++ b/custom_components/llmvision/const.py
@@ -147,6 +147,7 @@ DEFAULT_AWS_MODEL = "us.amazon.nova-pro-v1:0"
 DEFAULT_OPENWEBUI_MODEL = "gemma3:4b"
 DEFAULT_OPENROUTER_MODEL = "google/gemma-3-4b-it:free"
 DEFAULT_MISTRAL_MODEL = "pixtral-12b-2409"
+DEFAULT_REQUESTY_MODEL = "openai/gpt-4o-mini"
 
 DEFAULT_SUMMARY_PROMPT = "Provide a brief summary for the following titles. Focus on the key actions or changes that occurred over time and avoid unnecessary details or subjective interpretations. The summary should be concise, objective, and relevant to the content of the images. Keep the summary under 50 words and ensure it captures the main events or activities described in the descriptions. Here are the descriptions:\n "
 
@@ -161,3 +162,4 @@ ENDPOINT_OPENWEBUI = "{protocol}://{ip_address}:{port}/api/chat/completions"
 ENDPOINT_AZURE = "{base_url}openai/deployments/{deployment}/chat/completions?api-version={api_version}"
 ENDPOINT_OPENROUTER = "https://openrouter.ai/api/v1/chat/completions"
 ENDPOINT_MISTRAL = "https://api.mistral.ai/v1/chat/completions"
+ENDPOINT_REQUESTY = "https://router.requesty.ai/v1/chat/completions"

--- a/custom_components/llmvision/providers.py
+++ b/custom_components/llmvision/providers.py
@@ -37,6 +37,7 @@ from .const import (
     ENDPOINT_GROQ,
     ENDPOINT_OPENROUTER,
     ENDPOINT_MISTRAL,
+    ENDPOINT_REQUESTY,
     ERROR_NOT_CONFIGURED,
     ERROR_GROQ_MULTIPLE_IMAGES,
     ERROR_NO_IMAGE_INPUT,
@@ -52,6 +53,7 @@ from .const import (
     DEFAULT_OPENWEBUI_MODEL,
     DEFAULT_OPENROUTER_MODEL,
     DEFAULT_MISTRAL_MODEL,
+    DEFAULT_REQUESTY_MODEL,
     CONF_KEEP_ALIVE,
     CONF_CONTEXT_WINDOW,
     CONF_TEMPERATURE,
@@ -133,6 +135,7 @@ class Request:
             "Open WebUI": DEFAULT_OPENWEBUI_MODEL,
             "OpenRouter": DEFAULT_OPENROUTER_MODEL,
             "Mistral": DEFAULT_MISTRAL_MODEL,
+            "Requesty": DEFAULT_REQUESTY_MODEL,
         }.get(provider_name)
 
     def validate(self, call: Any) -> None | ServiceValidationError:
@@ -2293,6 +2296,14 @@ class ProviderFactory:
                 hass,
                 api_key=cast(str, config.get(CONF_API_KEY) or ""),
                 model=model,
+            )
+
+        if provider_name == "Requesty":
+            return OpenAI(
+                hass,
+                api_key=cast(str, config.get(CONF_API_KEY) or ""),
+                model=model,
+                endpoint={"base_url": ENDPOINT_REQUESTY},
             )
 
         raise ServiceValidationError("invalid_provider")

--- a/custom_components/llmvision/strings.json
+++ b/custom_components/llmvision/strings.json
@@ -389,6 +389,38 @@
                     }
                 }
             },
+            "requesty": {
+                "title": "Configure Requesty",
+                "description": "Requesty is an OpenAI-compatible router that provides access to various AI models. You can use it to connect to models like OpenAI, Anthropic, and more.",
+                "sections": {
+                    "connection_section": {
+                        "name": "Connection",
+                        "description": "Requesty authentication",
+                        "data": {
+                            "api_key": "API key"
+                        },
+                        "data_description": {
+                            "api_key": "Your Requesty API key. Make sure to add credit to your Requesty account first."
+                        }
+                    },
+                    "model_section": {
+                        "name": "Model",
+                        "description": "Set default model parameters",
+                        "data": {
+                            "default_model": "Default model",
+                            "temperature": "Temperature",
+                            "top_p": "Top P",
+                            "reasoning_effort": "Reasoning effort"
+                        },
+                        "data_description": {
+                            "default_model": "The default model to use when no other model is specified.",
+                            "temperature": "Controls the randomness of the output. Lower values make the output more deterministic.",
+                            "top_p": "Controls the diversity of the output. Lower values make the output more focused.",
+                            "reasoning_effort": "Controls the reasoning effort for models that support it."
+                        }
+                    }
+                }
+            },
             "settings": {
                 "title": "Settings",
                 "description": "Configure the LLM Vision integration. This entry is required before setting up other providers. If you wish to use the default settings, just press 'Submit'.",

--- a/custom_components/llmvision/translations/en.json
+++ b/custom_components/llmvision/translations/en.json
@@ -389,6 +389,38 @@
                     }
                 }
             },
+            "requesty": {
+                "title": "Configure Requesty",
+                "description": "Requesty is an OpenAI-compatible router that provides access to various AI models. You can use it to connect to models like OpenAI, Anthropic, and more.",
+                "sections": {
+                    "connection_section": {
+                        "name": "Connection",
+                        "description": "Requesty authentication",
+                        "data": {
+                            "api_key": "API key"
+                        },
+                        "data_description": {
+                            "api_key": "Your Requesty API key. Make sure to add credit to your Requesty account first."
+                        }
+                    },
+                    "model_section": {
+                        "name": "Model",
+                        "description": "Set default model parameters",
+                        "data": {
+                            "default_model": "Default model",
+                            "temperature": "Temperature",
+                            "top_p": "Top P",
+                            "reasoning_effort": "Reasoning effort"
+                        },
+                        "data_description": {
+                            "default_model": "The default model to use when no other model is specified.",
+                            "temperature": "Controls the randomness of the output. Lower values make the output more deterministic.",
+                            "top_p": "Controls the diversity of the output. Lower values make the output more focused.",
+                            "reasoning_effort": "Controls the reasoning effort for models that support it."
+                        }
+                    }
+                }
+            },
             "settings": {
                 "title": "Settings",
                 "description": "Configure the LLM Vision integration. This entry is required before setting up other providers. If you wish to use the default settings, just press 'Submit'.",


### PR DESCRIPTION
Adds Requesty as a provider, mirroring the existing OpenRouter provider as closely as possible.

Requesty (https://requesty.ai) is an OpenAI-compatible LLM router (base URL `https://router.requesty.ai/v1`, `provider/model` naming), so it reuses the shared `OpenAI` provider class with a different base URL, exactly how OpenRouter is wired.

Changes:
- `custom_components/llmvision/const.py`: `ENDPOINT_REQUESTY` and `DEFAULT_REQUESTY_MODEL` (`openai/gpt-4o-mini`), mirroring the OpenRouter constants.
- `custom_components/llmvision/providers.py`: `"Requesty"` in the default-model map and a `provider_name == "Requesty"` dispatch branch returning `OpenAI(..., endpoint={"base_url": ENDPOINT_REQUESTY})`.
- `custom_components/llmvision/config_flow.py`: Requesty added to the provider selector and an `async_step_requesty` config step mirroring `async_step_openrouter`.
- `custom_components/llmvision/strings.json` + `translations/en.json`: Requesty UI strings mirroring the OpenRouter step.
- `README.md`: Requesty added to the supported-providers list.

The default model id is verified live on Requesty.

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.
