### PR TITLE
fix(anthropic): support new-gen Claude models (sonnet-5, opus-4-8)

### DIFF
--- a/custom_components/llmvision/calendar.py
+++ b/custom_components/llmvision/calendar.py
@@ -7,12 +7,18 @@ from homeassistant.components.calendar import (
 from homeassistant.components.calendar.const import CalendarEntityFeature
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.debounce import Debouncer
 from homeassistant.config_entries import ConfigEntry
 from .const import SIGNAL_TIMELINE_UPDATED
 from .timeline import Timeline
 import logging
 
 _LOGGER = logging.getLogger(__name__)
+
+# Timeline writes can arrive in rapid bursts (one per analysed camera event) and
+# every refresh reloads the full events DB. Coalesce bursts into a single reload
+# after this quiet period instead of forcing one full reload per event.
+REFRESH_COOLDOWN_SECONDS = 1.5
 
 
 class Calendar(CalendarEntity):
@@ -27,6 +33,7 @@ class Calendar(CalendarEntity):
         self._events = []
         self._current_event = None
         self._attr_supported_features = CalendarEntityFeature.DELETE_EVENT
+        self._refresh_debouncer: Debouncer | None = None
 
     @property
     def icon(self) -> str:  # type: ignore
@@ -47,17 +54,41 @@ class Calendar(CalendarEntity):
         return dt
 
     async def async_added_to_hass(self) -> None:
-        """Subscribe to timeline-updated signals so UI state refreshes after writes."""
+        """Subscribe to timeline-updated signals so UI state refreshes after writes.
+
+        Writes can arrive in rapid bursts (one per analysed camera event) and each
+        refresh reloads the whole events DB. Debounce the refresh so a burst results
+        in a single reload instead of one full reload per event, which would
+        otherwise starve the event loop.
+        """
+
+        self._refresh_debouncer = Debouncer(
+            self.hass,
+            _LOGGER,
+            cooldown=REFRESH_COOLDOWN_SECONDS,
+            immediate=False,
+            function=self._async_refresh_state,
+        )
 
         @callback
         def _handle_timeline_updated() -> None:
-            self.async_schedule_update_ha_state(force_refresh=True)
+            self.hass.async_create_task(self._refresh_debouncer.async_call())
 
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass, SIGNAL_TIMELINE_UPDATED, _handle_timeline_updated
             )
         )
+
+    async def _async_refresh_state(self) -> None:
+        """Reload events from the database and write updated state (debounced)."""
+        await self.async_update_ha_state(force_refresh=True)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Cancel any pending debounced refresh when the entity is removed."""
+        if self._refresh_debouncer is not None:
+            await self._refresh_debouncer.async_shutdown()
+
     @property
     def extra_state_attributes(self) -> dict:  # type: ignore
         """Return the state attributes"""

--- a/custom_components/llmvision/config_flow.py
+++ b/custom_components/llmvision/config_flow.py
@@ -15,6 +15,7 @@ from .providers import (
     LocalAI,
     Ollama,
     AWSBedrock,
+    Mistral,
 )
 from .const import (
     DOMAIN,
@@ -54,6 +55,7 @@ from .const import (
     DEFAULT_AWS_MODEL,
     DEFAULT_OPENWEBUI_MODEL,
     DEFAULT_OPENROUTER_MODEL,
+    DEFAULT_MISTRAL_MODEL,
     ENDPOINT_OPENWEBUI,
     ENDPOINT_AZURE,
     ENDPOINT_OPENROUTER,
@@ -87,6 +89,7 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             "OpenAI": self.async_step_openai,
             "OpenWebUI": self.async_step_openwebui,
             "OpenRouter": self.async_step_openrouter,
+            "Mistral": self.async_step_mistral,
         }
 
         step_method = provider_steps.get(provider)
@@ -125,6 +128,7 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                                 "OpenAI",
                                 "OpenWebUI",
                                 "OpenRouter",
+                                "Mistral",
                                 "Custom OpenAI",
                             ],
                             "mode": "dropdown",
@@ -1629,6 +1633,99 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="openrouter",
+            data_schema=data_schema,
+        )
+
+    async def async_step_mistral(self, user_input=None):
+        data_schema = vol.Schema(
+            {
+                vol.Optional("connection_section"): section(
+                    vol.Schema(
+                        {
+                            vol.Required(CONF_API_KEY): selector(
+                                {"text": {"type": "password"}}
+                            ),
+                        }
+                    ),
+                    {"collapsed": False},
+                ),
+                vol.Optional("model_section"): section(
+                    vol.Schema(
+                        {
+                            vol.Required(
+                                CONF_DEFAULT_MODEL, default=DEFAULT_MISTRAL_MODEL
+                            ): str,
+                            vol.Optional(CONF_TEMPERATURE, default=0.5): selector(
+                                {
+                                    "number": {
+                                        "min": 0,
+                                        "max": 1,
+                                        "step": 0.1,
+                                        "mode": "slider",
+                                    }
+                                }
+                            ),
+                            vol.Optional(CONF_TOP_P, default=0.9): selector(
+                                {
+                                    "number": {
+                                        "min": 0,
+                                        "max": 1,
+                                        "step": 0.1,
+                                        "mode": "slider",
+                                    }
+                                }
+                            ),
+                        }
+                    ),
+                    {"collapsed": False},
+                ),
+            }
+        )
+
+        if self.source == config_entries.SOURCE_RECONFIGURE:
+            self.init_info = self._get_reconfigure_entry().data
+            suggested = {
+                "connection_section": {
+                    CONF_API_KEY: self.init_info.get(CONF_API_KEY),
+                },
+                "model_section": {
+                    CONF_DEFAULT_MODEL: self.init_info.get(
+                        CONF_DEFAULT_MODEL, DEFAULT_MISTRAL_MODEL
+                    ),
+                    CONF_TEMPERATURE: self.init_info.get(CONF_TEMPERATURE, 0.5),
+                    CONF_TOP_P: self.init_info.get(CONF_TOP_P, 0.9),
+                },
+            }
+            data_schema = self.add_suggested_values_to_schema(data_schema, suggested)
+
+        if user_input is not None:
+            user_input[CONF_PROVIDER] = self.init_info[CONF_PROVIDER]
+            user_input = flatten_dict(user_input)
+            try:
+                mistral = Mistral(
+                    self.hass,
+                    api_key=user_input[CONF_API_KEY],
+                    model=user_input[CONF_DEFAULT_MODEL],
+                )
+                await mistral.validate()
+                user_input[CONF_PROVIDER] = self.init_info[CONF_PROVIDER]
+                if self.source == config_entries.SOURCE_RECONFIGURE:
+                    return self.async_update_reload_and_abort(
+                        self._get_reconfigure_entry(),
+                        data_updates=user_input,
+                    )
+                else:
+                    return self.async_create_entry(title="Mistral", data=user_input)
+            except ServiceValidationError as e:
+                _LOGGER.error(f"Validation failed: {e}")
+                return self.async_show_form(
+                    step_id="mistral",
+                    data_schema=data_schema,
+                    errors={"base": "handshake_failed"},
+                )
+
+        return self.async_show_form(
+            step_id="mistral",
             data_schema=data_schema,
         )
 

--- a/custom_components/llmvision/config_flow.py
+++ b/custom_components/llmvision/config_flow.py
@@ -251,6 +251,25 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(step_id="localai", data_schema=data_schema)
 
+    def _validate_keep_alive(self, value):
+        """Validate Ollama keep_alive value."""
+        if value is None or (isinstance(value, (int, float))):
+            return value
+
+        val = str(value).strip()
+
+        # Numeric (integer or fractional), including negative
+        if re.fullmatch(r"[+-]?\d+(?:\.\d+)?", val):
+            # Return int when no fractional part
+            return int(val) if re.fullmatch(r"[+-]?\d+", val) else float(val)
+
+        # Go duration parts
+        dur_unit = r"(?:ns|us|µs|ms|s|m|h)"
+        if re.fullmatch(rf"[+-]?(?:\d+(?:\.\d+)?{dur_unit})+", val):
+            return val
+
+        raise ValueError("invalid keep_alive")
+
     async def async_step_ollama(self, user_input=None):
         data_schema = vol.Schema(
             {
@@ -340,6 +359,19 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             user_input[CONF_PROVIDER] = self.init_info[CONF_PROVIDER]
             # flatten dict to remove nested keys
             user_input = flatten_dict(user_input)
+            # Validate keep_alive early so we can show a useful form error
+            try:
+                if CONF_KEEP_ALIVE in user_input:
+                    user_input[CONF_KEEP_ALIVE] = self._validate_keep_alive(
+                        user_input.get(CONF_KEEP_ALIVE)
+                    )
+            except ValueError:
+                return self.async_show_form(
+                    step_id="ollama",
+                    data_schema=data_schema,
+                    errors={CONF_KEEP_ALIVE: "invalid_keep_alive"},
+                )
+
             try:
                 ollama = Ollama(
                     self.hass,
@@ -351,7 +383,7 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         ),
                         "port": user_input[CONF_PORT],
                         "https": user_input[CONF_HTTPS],
-                        "keep_alive": user_input[CONF_KEEP_ALIVE],
+                        "keep_alive": user_input.get(CONF_KEEP_ALIVE),
                         "context_window": user_input[CONF_CONTEXT_WINDOW],
                     },
                 )

--- a/custom_components/llmvision/config_flow.py
+++ b/custom_components/llmvision/config_flow.py
@@ -89,7 +89,8 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             "OpenAI": self.async_step_openai,
             "OpenWebUI": self.async_step_openwebui,
             "OpenRouter": self.async_step_openrouter,
-            "Mistral": self.async_step_mistral,
+            # TODO: Enable in next minor release (1.8.0).
+            # "Mistral": self.async_step_mistral,
         }
 
         step_method = provider_steps.get(provider)
@@ -128,7 +129,8 @@ class llmvisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                                 "OpenAI",
                                 "OpenWebUI",
                                 "OpenRouter",
-                                "Mistral",
+                                # TODO: Enable in next minor release (1.8.0).
+                                # "Mistral",
                                 "Custom OpenAI",
                             ],
                             "mode": "dropdown",

--- a/custom_components/llmvision/const.py
+++ b/custom_components/llmvision/const.py
@@ -146,6 +146,7 @@ DEFAULT_CUSTOM_OPENAI_MODEL = "gpt-4o-mini"
 DEFAULT_AWS_MODEL = "us.amazon.nova-pro-v1:0"
 DEFAULT_OPENWEBUI_MODEL = "gemma3:4b"
 DEFAULT_OPENROUTER_MODEL = "google/gemma-3-4b-it:free"
+DEFAULT_MISTRAL_MODEL = "pixtral-12b-2409"
 
 DEFAULT_SUMMARY_PROMPT = "Provide a brief summary for the following titles. Focus on the key actions or changes that occurred over time and avoid unnecessary details or subjective interpretations. The summary should be concise, objective, and relevant to the content of the images. Keep the summary under 50 words and ensure it captures the main events or activities described in the descriptions. Here are the descriptions:\n "
 
@@ -159,3 +160,4 @@ ENDPOINT_OLLAMA = "{protocol}://{ip_address}:{port}/api/chat"
 ENDPOINT_OPENWEBUI = "{protocol}://{ip_address}:{port}/api/chat/completions"
 ENDPOINT_AZURE = "{base_url}openai/deployments/{deployment}/chat/completions?api-version={api_version}"
 ENDPOINT_OPENROUTER = "https://openrouter.ai/api/v1/chat/completions"
+ENDPOINT_MISTRAL = "https://api.mistral.ai/v1/chat/completions"

--- a/custom_components/llmvision/manifest.json
+++ b/custom_components/llmvision/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/valentinfrlch/ha-llmvision/issues",
     "requirements": ["boto3==1.37.1", "aiosqlite==0.21.0", "aiofile==3.9.0"],
-    "version": "1.7.0"
+    "version": "1.7.1"
 }

--- a/custom_components/llmvision/manifest.json
+++ b/custom_components/llmvision/manifest.json
@@ -1,13 +1,22 @@
 {
-    "domain": "llmvision",
-    "name": "LLM Vision",
-    "codeowners": ["@valentinfrlch", "@TheRealFalseReality"],
-    "config_flow": true,
-    "dependencies": ["http"],
-    "documentation": "https://llmvision.gitbook.io/getting-started/",
-    "integration_type": "service",
-    "iot_class": "cloud_polling",
-    "issue_tracker": "https://github.com/valentinfrlch/ha-llmvision/issues",
-    "requirements": ["boto3==1.37.1", "aiosqlite==0.21.0", "aiofile==3.9.0"],
-    "version": "1.7.1"
+  "domain": "llmvision",
+  "name": "LLM Vision",
+  "codeowners": [
+    "@valentinfrlch",
+    "@TheRealFalseReality"
+  ],
+  "config_flow": true,
+  "dependencies": [
+    "http"
+  ],
+  "documentation": "https://llmvision.gitbook.io/getting-started/",
+  "integration_type": "service",
+  "iot_class": "cloud_polling",
+  "issue_tracker": "https://github.com/valentinfrlch/ha-llmvision/issues",
+  "requirements": [
+    "boto3==1.37.1",
+    "aiosqlite==0.21.0",
+    "aiofile==3.9.0"
+  ],
+  "version": "1.7.2-newgen"
 }

--- a/custom_components/llmvision/providers.py
+++ b/custom_components/llmvision/providers.py
@@ -36,6 +36,7 @@ from .const import (
     ENDPOINT_OPENWEBUI,
     ENDPOINT_GROQ,
     ENDPOINT_OPENROUTER,
+    ENDPOINT_MISTRAL,
     ERROR_NOT_CONFIGURED,
     ERROR_GROQ_MULTIPLE_IMAGES,
     ERROR_NO_IMAGE_INPUT,
@@ -50,6 +51,7 @@ from .const import (
     DEFAULT_AWS_MODEL,
     DEFAULT_OPENWEBUI_MODEL,
     DEFAULT_OPENROUTER_MODEL,
+    DEFAULT_MISTRAL_MODEL,
     CONF_KEEP_ALIVE,
     CONF_CONTEXT_WINDOW,
     CONF_TEMPERATURE,
@@ -130,6 +132,7 @@ class Request:
             "AWS": DEFAULT_AWS_MODEL,  # For backwards compatibility
             "Open WebUI": DEFAULT_OPENWEBUI_MODEL,
             "OpenRouter": DEFAULT_OPENROUTER_MODEL,
+            "Mistral": DEFAULT_MISTRAL_MODEL,
         }.get(provider_name)
 
     def validate(self, call: Any) -> None | ServiceValidationError:
@@ -789,6 +792,28 @@ class OpenAI(Provider):
             )
         else:
             raise ServiceValidationError("empty_api_key")
+
+
+class Mistral(OpenAI):
+    """Mistral (https://docs.mistral.ai/api/). OpenAI-compatible but rejects
+    unknown fields, so rename max_completion_tokens to max_tokens."""
+
+    def __init__(self, hass: HomeAssistant, api_key: str, model: str):
+        super().__init__(
+            hass, api_key, model, endpoint={"base_url": ENDPOINT_MISTRAL}
+        )
+
+    @staticmethod
+    def _rename_token_field(payload: dict) -> dict:
+        if "max_completion_tokens" in payload:
+            payload["max_tokens"] = payload.pop("max_completion_tokens")
+        return payload
+
+    def _prepare_vision_data(self, call: Any) -> dict:
+        return self._rename_token_field(super()._prepare_vision_data(call))
+
+    def _prepare_text_data(self, call: Any) -> dict:
+        return self._rename_token_field(super()._prepare_text_data(call))
 
 
 class AzureOpenAI(Provider):
@@ -2158,6 +2183,13 @@ class ProviderFactory:
                 api_key=cast(str, config.get(CONF_API_KEY) or ""),
                 model=model,
                 endpoint={"base_url": ENDPOINT_OPENROUTER},
+            )
+
+        if provider_name == "Mistral":
+            return Mistral(
+                hass,
+                api_key=cast(str, config.get(CONF_API_KEY) or ""),
+                model=model,
             )
 
         raise ServiceValidationError("invalid_provider")

--- a/custom_components/llmvision/providers.py
+++ b/custom_components/llmvision/providers.py
@@ -601,21 +601,37 @@ class OpenAI(Provider):
         """OpenAI supports structured output via JSON Schema."""
         return True
 
+    def _normalize_reasoning_effort(self, value: Any) -> str:
+        """Normalize reasoning effort to a known value."""
+        effort = str(value).strip().lower() if value is not None else "none"
+        allowed = {"none", "minimal", "low", "medium", "high", "xhigh"}
+        return effort if effort in allowed else "none"
+
     def _model_supports_thinking(self, max_effort: str) -> str | bool:
         """Returns the highest supported reasoning effort for the model that is <= the reasoning effort from config"""
         models = {
+            "gpt-5.5": ["none", "low", "medium", "high", "xhigh"],
+            "gpt-5.4-pro": ["medium", "high", "xhigh"],
+            "gpt-5.4-mini": ["none", "low", "medium", "high", "xhigh"],
+            "gpt-5.4-nano": ["none", "low", "medium", "high", "xhigh"],
             "gpt-5.4": ["none", "low", "medium", "high", "xhigh"],
+            "gpt-5.2": ["none", "low", "medium", "high", "xhigh"],
             "gpt-5.1": ["none", "low", "medium", "high"],
             "gpt-5-pro": ["high"],
             "gpt-5-mini": ["medium"],
             "gpt-5-nano": ["medium"],
         }
-        effort_order = ["none", "low", "medium", "high", "xhigh"]
-        for model_prefix, efforts in models.items():
+        effort_order = ["none", "minimal", "low", "medium", "high", "xhigh"]
+        normalized_effort = self._normalize_reasoning_effort(max_effort)
+        # Match the most specific model prefix first to avoid broad prefix collisions
+        for model_prefix in sorted(models, key=len, reverse=True):
+            efforts = models[model_prefix]
             if self.model.startswith(model_prefix):
                 # return the highest reasoning effort supported by the model that is less than or equal to the requested max_effort
                 for effort in reversed(effort_order):
-                    if effort in efforts and effort_order.index(effort) <= effort_order.index(max_effort):
+                    if effort in efforts and effort_order.index(
+                        effort
+                    ) <= effort_order.index(normalized_effort):
                         return effort
         return False
 
@@ -676,12 +692,12 @@ class OpenAI(Provider):
         }
 
         # Add reasoning effort if enabled and supported by model
-        max_effort = default_parameters.get("reasoning_effort", "none")
-        if (
-            max_effort not in ["none", None]
-            and self._model_supports_thinking(max_effort) != False
-        ):
-            payload["reasoning_effort"] = self._model_supports_thinking(max_effort)
+        max_effort = self._normalize_reasoning_effort(
+            default_parameters.get("reasoning_effort", "none")
+        )
+        supported_effort = self._model_supports_thinking(max_effort)
+        if max_effort != "none" and supported_effort != False:
+            payload["reasoning_effort"] = supported_effort
 
         # Remove temperature and top_p if model is gpt-5
         if self.model in ["gpt-5", "gpt-5-mini", "gpt-5-nano"]:
@@ -761,12 +777,12 @@ class OpenAI(Provider):
         }
 
         # Add reasoning effort if enabled and supported by model
-        max_effort = default_parameters.get("reasoning_effort", "none")
-        if (
-            max_effort not in ["none", None]
-            and self._model_supports_thinking(max_effort) != False
-        ):
-            payload["reasoning_effort"] = self._model_supports_thinking(max_effort)
+        max_effort = self._normalize_reasoning_effort(
+            default_parameters.get("reasoning_effort", "none")
+        )
+        supported_effort = self._model_supports_thinking(max_effort)
+        if max_effort != "none" and supported_effort != False:
+            payload["reasoning_effort"] = supported_effort
 
         # Remove temperature and top_p if model is gpt-5
         if self.model in ["gpt-5", "gpt-5-mini", "gpt-5-nano"]:
@@ -784,9 +800,7 @@ class OpenAI(Provider):
                     {"role": "user", "content": [{"type": "text", "text": "Hi"}]}
                 ],
             }
-            await self._post(
-                url=self._get_request_url(), headers=headers, data=data
-            )
+            await self._post(url=self._get_request_url(), headers=headers, data=data)
         else:
             raise ServiceValidationError("empty_api_key")
 
@@ -1009,6 +1023,25 @@ class Anthropic(Provider):
                 return content.get("text", "")
         return ""
 
+    def _normalize_thinking_budget(self, value: Any) -> int:
+        """Normalize thinking budget to a non-negative integer."""
+        try:
+            budget = int(float(value))
+        except (TypeError, ValueError):
+            return 0
+        return max(0, budget)
+
+    def _build_thinking_config(
+        self, default_parameters: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Build Anthropic thinking config and enforce API minimum when enabled."""
+        budget_tokens = self._normalize_thinking_budget(
+            default_parameters.get("thinking_budget", 0)
+        )
+        if budget_tokens >= 1024:
+            return {"type": "enabled", "budget_tokens": budget_tokens}
+        return {"type": "disabled"}
+
     def _prepare_vision_data(self, call: Any) -> dict:
         default_parameters = self._get_default_parameters(call)
         payload = {
@@ -1016,11 +1049,9 @@ class Anthropic(Provider):
             "messages": [{"role": "user", "content": []}],
             "max_tokens": call.max_tokens,
             "temperature": default_parameters.get("temperature"),
-            "thinking": {
-                "type": "enabled",
-                "budget_tokens": default_parameters.get("thinking_budget", 0),
-            },
         }
+        thinking_config = self._build_thinking_config(default_parameters)
+        payload["thinking"] = thinking_config
 
         # Add structured output support using tools
         if call.response_format == "json" and call.structure:
@@ -1093,11 +1124,9 @@ class Anthropic(Provider):
             ],
             "max_tokens": call.max_tokens,
             "temperature": default_parameters.get("temperature"),
-            "thinking": {
-                "type": "enabled",
-                "budget_tokens": default_parameters.get("thinking_budget", 0),
-            },
         }
+        thinking_config = self._build_thinking_config(default_parameters)
+        payload["thinking"] = thinking_config
 
         # Add structured output support using tools
         if call.response_format == "json" and call.structure:

--- a/custom_components/llmvision/providers.py
+++ b/custom_components/llmvision/providers.py
@@ -922,8 +922,6 @@ class AzureOpenAI(Provider):
 
         # Add structured output format if requested
         if call.response_format == "json" and call.structure:
-            import json
-
             try:
                 schema = (
                     json.loads(call.structure)
@@ -970,8 +968,6 @@ class AzureOpenAI(Provider):
 
         # Add structured output format if requested
         if call.response_format == "json" and call.structure:
-            import json
-
             try:
                 schema = (
                     json.loads(call.structure)
@@ -1057,9 +1053,11 @@ class Anthropic(Provider):
         return max(0, budget)
 
     def _build_thinking_config(
-        self, default_parameters: dict[str, Any]
+        self, default_parameters: dict[str, Any], forces_tool_use: bool = False
     ) -> dict[str, Any]:
         """Build Anthropic thinking config and enforce API minimum when enabled."""
+        if forces_tool_use:
+            return {"type": "disabled"}
         budget_tokens = self._normalize_thinking_budget(
             default_parameters.get("thinking_budget", 0)
         )
@@ -1069,19 +1067,22 @@ class Anthropic(Provider):
 
     def _prepare_vision_data(self, call: Any) -> dict:
         default_parameters = self._get_default_parameters(call)
+        forces_tool_use = bool(call.response_format == "json" and call.structure)
+        thinking_config = self._build_thinking_config(
+            default_parameters, forces_tool_use=forces_tool_use
+        )
         payload = {
             "model": self.model,
             "messages": [{"role": "user", "content": []}],
             "max_tokens": call.max_tokens,
-            "temperature": default_parameters.get("temperature"),
+            "thinking": thinking_config,
         }
-        thinking_config = self._build_thinking_config(default_parameters)
-        payload["thinking"] = thinking_config
+        # Omit temperature if thinking is enabled
+        if thinking_config.get("type") != "enabled":
+            payload["temperature"] = default_parameters.get("temperature")
 
         # Add structured output support using tools
         if call.response_format == "json" and call.structure:
-            import json
-
             try:
                 schema = (
                     json.loads(call.structure)
@@ -1141,6 +1142,10 @@ class Anthropic(Provider):
     def _prepare_text_data(self, call: Any) -> dict:
         default_parameters = self._get_default_parameters(call)
         title_prompt = self._get_title_prompt()
+        forces_tool_use = bool(call.response_format == "json" and call.structure)
+        thinking_config = self._build_thinking_config(
+            default_parameters, forces_tool_use=forces_tool_use
+        )
         payload = {
             "model": self.model,
             "messages": [
@@ -1148,15 +1153,14 @@ class Anthropic(Provider):
                 {"role": "user", "content": [{"type": "text", "text": call.message}]},
             ],
             "max_tokens": call.max_tokens,
-            "temperature": default_parameters.get("temperature"),
+            "thinking": thinking_config,
         }
-        thinking_config = self._build_thinking_config(default_parameters)
-        payload["thinking"] = thinking_config
+        # Omit temperature if thinking is enabled
+        if thinking_config.get("type") != "enabled":
+            payload["temperature"] = default_parameters.get("temperature")
 
         # Add structured output support using tools
         if call.response_format == "json" and call.structure:
-            import json
-
             try:
                 schema = (
                     json.loads(call.structure)
@@ -1264,8 +1268,6 @@ class Google(Provider):
 
         # Add structured output support
         if call.response_format == "json" and call.structure:
-            import json
-
             try:
                 schema = (
                     json.loads(call.structure)
@@ -1330,8 +1332,6 @@ class Google(Provider):
 
         # Add structured output support
         if call.response_format == "json" and call.structure:
-            import json
-
             try:
                 schema = (
                     json.loads(call.structure)
@@ -1430,8 +1430,6 @@ class Groq(Provider):
 
         # Add structured output format if requested
         if call.response_format == "json" and call.structure:
-            import json
-
             try:
                 schema = (
                     json.loads(call.structure)
@@ -1468,8 +1466,6 @@ class Groq(Provider):
 
         # Add structured output format if requested
         if call.response_format == "json" and call.structure:
-            import json
-
             try:
                 schema = (
                     json.loads(call.structure)
@@ -1588,8 +1584,6 @@ class LocalAI(Provider):
 
         # Add structured output support (OpenAI-compatible)
         if call.response_format == "json" and call.structure:
-            import json
-
             try:
                 schema = (
                     json.loads(call.structure)
@@ -1626,8 +1620,6 @@ class LocalAI(Provider):
 
         # Add structured output support (OpenAI-compatible)
         if call.response_format == "json" and call.structure:
-            import json
-
             try:
                 schema = (
                     json.loads(call.structure)
@@ -1739,8 +1731,6 @@ class Ollama(Provider):
 
         # Add structured output support
         if call.response_format == "json" and call.structure:
-            import json
-
             try:
                 schema = (
                     json.loads(call.structure)
@@ -1784,8 +1774,6 @@ class Ollama(Provider):
 
         # Add structured output support
         if call.response_format == "json" and call.structure:
-            import json
-
             try:
                 schema = (
                     json.loads(call.structure)
@@ -2014,8 +2002,6 @@ class AWSBedrock(Provider):
 
         # Add structured output support using tool definitions
         if call.response_format == "json" and call.structure:
-            import json
-
             try:
                 schema = (
                     json.loads(call.structure)
@@ -2058,8 +2044,6 @@ class AWSBedrock(Provider):
 
         # Add structured output support using tool definitions
         if call.response_format == "json" and call.structure:
-            import json
-
             try:
                 schema = (
                     json.loads(call.structure)

--- a/custom_components/llmvision/providers.py
+++ b/custom_components/llmvision/providers.py
@@ -1052,15 +1052,41 @@ class Anthropic(Provider):
             return 0
         return max(0, budget)
 
+    # Newer Claude models reject `temperature`/`top_p` and the fixed
+    # `thinking.budget_tokens`; they require adaptive thinking instead.
+    _NEW_GEN_MARKERS = (
+        "claude-opus-4-6",
+        "claude-opus-4-7",
+        "claude-opus-4-8",
+        "claude-sonnet-5",
+        "claude-sonnet-4-6",
+        "claude-fable-5",
+        "claude-mythos-5",
+    )
+
+    def _is_new_gen(self) -> bool:
+        """True for models that reject temperature and fixed thinking budgets."""
+        model = (self.model or "").lower()
+        return any(marker in model for marker in self._NEW_GEN_MARKERS)
+
     def _build_thinking_config(
         self, default_parameters: dict[str, Any], forces_tool_use: bool = False
-    ) -> dict[str, Any]:
-        """Build Anthropic thinking config and enforce API minimum when enabled."""
-        if forces_tool_use:
-            return {"type": "disabled"}
+    ) -> dict[str, Any] | None:
+        """Build Anthropic thinking config.
+
+        New-gen models use adaptive thinking (no budget_tokens) and cannot
+        combine thinking with forced tool use -> return None (omit the key).
+        Legacy models keep the fixed-budget behaviour.
+        """
         budget_tokens = self._normalize_thinking_budget(
             default_parameters.get("thinking_budget", 0)
         )
+        if self._is_new_gen():
+            if forces_tool_use or budget_tokens <= 0:
+                return None
+            return {"type": "adaptive"}
+        if forces_tool_use:
+            return {"type": "disabled"}
         if budget_tokens >= 1024:
             return {"type": "enabled", "budget_tokens": budget_tokens}
         return {"type": "disabled"}
@@ -1075,10 +1101,12 @@ class Anthropic(Provider):
             "model": self.model,
             "messages": [{"role": "user", "content": []}],
             "max_tokens": call.max_tokens,
-            "thinking": thinking_config,
         }
-        # Omit temperature if thinking is enabled
-        if thinking_config.get("type") != "enabled":
+        if thinking_config is not None:
+            payload["thinking"] = thinking_config
+        # New-gen Claude models reject temperature; legacy models omit it only
+        # while fixed-budget thinking is enabled.
+        if not self._is_new_gen() and (thinking_config or {}).get("type") != "enabled":
             payload["temperature"] = default_parameters.get("temperature")
 
         # Add structured output support using tools
@@ -1153,10 +1181,12 @@ class Anthropic(Provider):
                 {"role": "user", "content": [{"type": "text", "text": call.message}]},
             ],
             "max_tokens": call.max_tokens,
-            "thinking": thinking_config,
         }
-        # Omit temperature if thinking is enabled
-        if thinking_config.get("type") != "enabled":
+        if thinking_config is not None:
+            payload["thinking"] = thinking_config
+        # New-gen Claude models reject temperature; legacy models omit it only
+        # while fixed-budget thinking is enabled.
+        if not self._is_new_gen() and (thinking_config or {}).get("type") != "enabled":
             payload["temperature"] = default_parameters.get("temperature")
 
         # Add structured output support using tools
@@ -1196,8 +1226,9 @@ class Anthropic(Provider):
             "model": self.model,
             "messages": [{"role": "user", "content": "Hi"}],
             "max_tokens": 1,
-            "temperature": 0.5,
         }
+        if not self._is_new_gen():
+            payload["temperature"] = 0.5
         await self._post(
             url=f"https://api.anthropic.com/v1/messages", headers=header, data=payload
         )

--- a/custom_components/llmvision/strings.json
+++ b/custom_components/llmvision/strings.json
@@ -359,6 +359,36 @@
                     }
                 }
             },
+            "mistral": {
+                "title": "Configure Mistral",
+                "description": "Vision-capable models (Pixtral) hosted by Mistral AI in the EU.",
+                "sections": {
+                    "connection_section": {
+                        "name": "Connection",
+                        "description": "Mistral authentication",
+                        "data": {
+                            "api_key": "API key"
+                        },
+                        "data_description": {
+                            "api_key": "Your Mistral API key from https://console.mistral.ai/."
+                        }
+                    },
+                    "model_section": {
+                        "name": "Model",
+                        "description": "Set default model parameters",
+                        "data": {
+                            "default_model": "Default model",
+                            "temperature": "Temperature",
+                            "top_p": "Top P"
+                        },
+                        "data_description": {
+                            "default_model": "Default Mistral model (e.g. pixtral-12b-2409, pixtral-large-latest).",
+                            "temperature": "Controls the randomness of the output. Lower values make the output more deterministic.",
+                            "top_p": "Controls the diversity of the output. Lower values make the output more focused."
+                        }
+                    }
+                }
+            },
             "settings": {
                 "title": "Settings",
                 "description": "Configure the LLM Vision integration. This entry is required before setting up other providers. If you wish to use the default settings, just press 'Submit'.",

--- a/custom_components/llmvision/strings.json
+++ b/custom_components/llmvision/strings.json
@@ -110,7 +110,7 @@
                             "default_model": "The default model to use when no other model is specified.",
                             "temperature": "Controls the randomness of the output. Lower values make the output more deterministic.",
                             "top_p": "Controls the diversity of the output. Lower values make the output more focused.",
-                            "reasoning_effort": "Controls the reasoning effort for models that support it."
+                            "reasoning_effort": "Controls the reasoning effort for models that support it. None disables thinking."
                         }
                     }
                 }
@@ -172,7 +172,7 @@
                             "default_model": "The default model to use when no other model is specified.",
                             "temperature": "Controls the randomness of the output. Lower values make the output more deterministic.",
                             "top_p": "Controls the diversity of the output. Lower values make the output more focused.",
-                            "thinking_budget": "Controls the thinking budget for models that support it. Higher values allow for more complex reasoning but may increase response time and cost."
+                            "thinking_budget": "Controls the thinking budget for models that support it. Higher values allow for more complex reasoning but may increase response time and cost. 0 disables thinking."
                         }
                     }
                 }

--- a/custom_components/llmvision/strings.json
+++ b/custom_components/llmvision/strings.json
@@ -370,7 +370,7 @@
                             "api_key": "API key"
                         },
                         "data_description": {
-                            "api_key": "Your Mistral API key from https://console.mistral.ai/."
+                            "api_key": "Your Mistral API key from the Mistral console."
                         }
                     },
                     "model_section": {

--- a/custom_components/llmvision/timeline.py
+++ b/custom_components/llmvision/timeline.py
@@ -807,7 +807,9 @@ class Timeline:
             if pending_name:
                 self._pending_key_frames.add(pending_name)
             try:
-                await self.load_events()
+                # No pre-load needed: the in-memory list is not read before the
+                # insert below, and _insert_event() reloads it afterwards. Skipping
+                # this redundant full-DB reload keeps event creation off the hot path.
 
                 # Resolve category and label if not provided
                 if not label:

--- a/custom_components/llmvision/timeline.py
+++ b/custom_components/llmvision/timeline.py
@@ -974,7 +974,7 @@ class Timeline:
             # Skip cleanup during migration
             return
 
-        GRACE_SECONDS = 10
+        GRACE_SECONDS = 30
 
         async with self._cleanup_lock:
             linked_frames = {

--- a/custom_components/llmvision/translations/en.json
+++ b/custom_components/llmvision/translations/en.json
@@ -359,6 +359,36 @@
                     }
                 }
             },
+            "mistral": {
+                "title": "Configure Mistral",
+                "description": "Vision-capable models (Pixtral) hosted by Mistral AI in the EU.",
+                "sections": {
+                    "connection_section": {
+                        "name": "Connection",
+                        "description": "Mistral authentication",
+                        "data": {
+                            "api_key": "API key"
+                        },
+                        "data_description": {
+                            "api_key": "Your Mistral API key from https://console.mistral.ai/."
+                        }
+                    },
+                    "model_section": {
+                        "name": "Model",
+                        "description": "Set default model parameters",
+                        "data": {
+                            "default_model": "Default model",
+                            "temperature": "Temperature",
+                            "top_p": "Top P"
+                        },
+                        "data_description": {
+                            "default_model": "Default Mistral model (e.g. pixtral-12b-2409, pixtral-large-latest).",
+                            "temperature": "Controls the randomness of the output. Lower values make the output more deterministic.",
+                            "top_p": "Controls the diversity of the output. Lower values make the output more focused."
+                        }
+                    }
+                }
+            },
             "settings": {
                 "title": "Settings",
                 "description": "Configure the LLM Vision integration. This entry is required before setting up other providers. If you wish to use the default settings, just press 'Submit'.",

--- a/custom_components/llmvision/translations/en.json
+++ b/custom_components/llmvision/translations/en.json
@@ -110,7 +110,7 @@
                             "default_model": "The default model to use when no other model is specified.",
                             "temperature": "Controls the randomness of the output. Lower values make the output more deterministic.",
                             "top_p": "Controls the diversity of the output. Lower values make the output more focused.",
-                            "reasoning_effort": "Controls the reasoning effort for models that support it."
+                            "reasoning_effort": "Controls the reasoning effort for models that support it. None disables thinking."
                         }
                     }
                 }
@@ -172,7 +172,7 @@
                             "default_model": "The default model to use when no other model is specified.",
                             "temperature": "Controls the randomness of the output. Lower values make the output more deterministic.",
                             "top_p": "Controls the diversity of the output. Lower values make the output more focused.",
-                            "thinking_budget": "Controls the thinking budget for models that support it. Higher values allow for more complex reasoning but may increase response time and cost."
+                            "thinking_budget": "Controls the thinking budget for models that support it. Higher values allow for more complex reasoning but may increase response time and cost. 0 disables thinking."
                         }
                     }
                 }

--- a/custom_components/llmvision/translations/en.json
+++ b/custom_components/llmvision/translations/en.json
@@ -370,7 +370,7 @@
                             "api_key": "API key"
                         },
                         "data_description": {
-                            "api_key": "Your Mistral API key from https://console.mistral.ai/."
+                            "api_key": "Your Mistral API key from the Mistral console."
                         }
                     },
                     "model_section": {

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -219,6 +219,55 @@ class TestCalendar:
 
         mock_timeline.delete_event.assert_called_once_with(uid)
 
+    @pytest.mark.asyncio
+    async def test_timeline_updates_are_debounced(self, calendar_instance):
+        """Timeline-updated signals refresh via a debouncer, not a direct reload.
+
+        A burst of camera events (one signal each) must coalesce into a single
+        reload instead of one full DB reload per event, which would otherwise
+        saturate the event loop.
+        """
+        calendar_instance.async_on_remove = Mock()
+        with patch(
+            "custom_components.llmvision.calendar.Debouncer"
+        ) as mock_debouncer, patch(
+            "custom_components.llmvision.calendar.async_dispatcher_connect"
+        ) as mock_connect:
+            await calendar_instance.async_added_to_hass()
+
+        # A debouncer was created with the refresh coroutine and a non-zero cooldown.
+        mock_debouncer.assert_called_once()
+        _, kwargs = mock_debouncer.call_args
+        assert kwargs["function"] == calendar_instance._async_refresh_state
+        assert kwargs["cooldown"] > 0
+
+        # The signal handler routes through the debouncer instead of refreshing inline.
+        mock_connect.assert_called_once()
+        signal_handler = mock_connect.call_args[0][2]
+        signal_handler()
+        calendar_instance.hass.async_create_task.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_async_refresh_state_forces_full_reload(self, calendar_instance):
+        """The debounced refresh performs a force_refresh state update."""
+        calendar_instance.async_update_ha_state = AsyncMock()
+
+        await calendar_instance._async_refresh_state()
+
+        calendar_instance.async_update_ha_state.assert_awaited_once_with(
+            force_refresh=True
+        )
+
+    @pytest.mark.asyncio
+    async def test_pending_refresh_cancelled_on_removal(self, calendar_instance):
+        """Removing the entity shuts the debouncer down to cancel a pending refresh."""
+        debouncer = AsyncMock()
+        calendar_instance._refresh_debouncer = debouncer
+
+        await calendar_instance.async_will_remove_from_hass()
+
+        debouncer.async_shutdown.assert_awaited_once()
+
 
 class TestCalendarAdvanced:
     """Advanced tests for Calendar class."""

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -953,3 +953,44 @@ class TestFlattenDict:
         result = flatten_dict(flat)
 
         assert result == flat
+
+
+class TestKeepAliveValidation:
+    """Tests for keep_alive validation helper in the config flow."""
+
+    def test_validate_keep_alive_numbers_and_strings(self, build_flow):
+        flow = build_flow()
+
+        # Integer input
+        assert flow._validate_keep_alive(3600) == 3600
+        assert flow._validate_keep_alive("3600") == 3600
+
+        # Fractional seconds
+        assert flow._validate_keep_alive("42.5") == 42.5
+
+        # Zero
+        assert flow._validate_keep_alive("0") == 0
+
+        # Negative integer
+        assert flow._validate_keep_alive("-1") == -1
+
+    def test_validate_keep_alive_go_duration_strings(self, build_flow):
+        flow = build_flow()
+
+        # Simple duration
+        assert flow._validate_keep_alive("5m") == "5m"
+
+        # Composite duration
+        assert flow._validate_keep_alive("1h2m3s") == "1h2m3s"
+
+        # Negative duration (meaning keep loaded indefinitely per Ollama semantics)
+        assert flow._validate_keep_alive("-1m") == "-1m"
+
+    def test_validate_keep_alive_invalid_raises(self, build_flow):
+        flow = build_flow()
+
+        with pytest.raises(ValueError):
+            flow._validate_keep_alive("not-a-duration")
+
+        with pytest.raises(ValueError):
+            flow._validate_keep_alive("")

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -17,6 +17,7 @@ from custom_components.llmvision.providers import (
     LocalAI,
     Ollama,
     AWSBedrock,
+    Mistral,
     ProviderFactory,
 )
 from custom_components.llmvision.const import (
@@ -52,6 +53,8 @@ from custom_components.llmvision.const import (
     DEFAULT_OLLAMA_MODEL,
     DEFAULT_SYSTEM_PROMPT,
     DEFAULT_TITLE_PROMPT,
+    DEFAULT_MISTRAL_MODEL,
+    ENDPOINT_MISTRAL,
 )
 
 
@@ -661,6 +664,75 @@ class TestOpenAI:
             assert result is False
 
 
+class TestMistral:
+    """Test Mistral provider class."""
+
+    def test_init_uses_mistral_endpoint(self, mock_hass):
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            mistral = Mistral(mock_hass, "test_api_key", "pixtral-12b-2409")
+
+            assert mistral.api_key == "test_api_key"
+            assert mistral.model == "pixtral-12b-2409"
+            assert mistral.endpoint["base_url"] == ENDPOINT_MISTRAL
+
+    def test_prepare_vision_data_uses_max_tokens(self, mock_hass):
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            mistral = Mistral(mock_hass, "test_api_key", "pixtral-12b-2409")
+            call = Mock()
+            call.max_tokens = 1000
+            call.base64_images = ["base64_image"]
+            call.filenames = ["test.jpg"]
+            call.message = "Describe this image"
+            call.provider = "test_provider"
+            call.response_format = "text"
+            call.use_memory = False
+            call.structure = None
+
+            mock_hass.data = {
+                DOMAIN: {
+                    "test_provider": {
+                        "provider": "Mistral",
+                        "temperature": 0.7,
+                        "top_p": 0.9,
+                    }
+                }
+            }
+
+            with patch.object(
+                mistral, "_get_system_prompt", return_value="System prompt"
+            ):
+                result = mistral._prepare_vision_data(call)
+
+            assert result["max_tokens"] == 1000
+            assert "max_completion_tokens" not in result
+
+    def test_prepare_text_data_uses_max_tokens(self, mock_hass):
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            mistral = Mistral(mock_hass, "test_api_key", "pixtral-12b-2409")
+            call = Mock()
+            call.max_tokens = 1000
+            call.message = "Generate a title"
+            call.provider = "test_provider"
+
+            mock_hass.data = {
+                DOMAIN: {
+                    "test_provider": {
+                        "provider": "Mistral",
+                        "temperature": 0.7,
+                        "top_p": 0.9,
+                    }
+                }
+            }
+
+            with patch.object(
+                mistral, "_get_title_prompt", return_value="Title prompt"
+            ):
+                result = mistral._prepare_text_data(call)
+
+            assert result["max_tokens"] == 1000
+            assert "max_completion_tokens" not in result
+
+
 class TestAzureOpenAI:
     """Test AzureOpenAI provider class."""
 
@@ -1128,6 +1200,18 @@ class TestProviderFactory:
             )
 
             assert isinstance(provider, OpenAI)
+
+    def test_create_mistral(self, mock_hass):
+        config = {CONF_API_KEY: "test_key"}
+
+        with patch("custom_components.llmvision.providers.async_get_clientsession"):
+            provider = ProviderFactory.create(
+                mock_hass, "Mistral", config, "pixtral-12b-2409"
+            )
+
+            assert isinstance(provider, Mistral)
+            assert isinstance(provider, OpenAI)
+            assert provider.endpoint["base_url"] == ENDPOINT_MISTRAL
 
 
 @pytest.fixture


### PR DESCRIPTION
## Problem

Newer Claude models (Opus 4.6/4.7/4.8, Sonnet 5, Sonnet 4.6, Fable 5) reject the parameters the Anthropic provider still sends, so every request fails:

- ```temperature` is deprecated for this model.``` — sampling params are removed on these models (400)
- `thinking.enabled.budget_tokens: Input should be a valid integer` — fixed-budget extended thinking is removed; only adaptive thinking is accepted (400)

Even after v1.7.1-beta.2 (which normalized the budget and disabled thinking under forced tool use), `temperature` is still sent whenever thinking is not `enabled` — which is the default path — so new-gen models remain unusable.

## Fix

Make the Anthropic provider model-aware:

- `_is_new_gen()` detects opus-4-6/4-7/4-8, sonnet-5, sonnet-4-6, fable-5, mythos-5.
- New-gen: never send `temperature`; thinking uses `{"type": "adaptive"}` (only when a budget is configured and no forced tool_choice), otherwise the `thinking` key is omitted.
- `validate()` omits `temperature` for new-gen models.
- Legacy models: unchanged behaviour (enabled + budget_tokens >= 1024).

No config/schema changes. Backwards compatible.