### PR TITLE
fix: relax boto3 pin to avoid conflict with HA core constraint

### DIFF
--- a/custom_components/llmvision/manifest.json
+++ b/custom_components/llmvision/manifest.json
@@ -8,6 +8,6 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/valentinfrlch/ha-llmvision/issues",
-    "requirements": ["boto3==1.37.1", "aiosqlite==0.21.0", "aiofile==3.9.0"],
+    "requirements": ["boto3>=1.37.1", "aiosqlite==0.21.0", "aiofile==3.9.0"],
     "version": "1.7.0"
 }


### PR DESCRIPTION
## Summary
- HA Core 2026.8 added a global constraint pinning `boto3==1.42.97` / `botocore==1.42.97` in `package_constraints.txt`
- `manifest.json` pinned `boto3==1.37.1` exactly, which is unsatisfiable alongside core's pin, so dependency install fails and every LLM Vision config entry stays `not_loaded`
- Relaxes the manifest requirement to `boto3>=1.37.1` so pip can resolve to whatever version core constrains, fixing setup on HA 2026.8+ while staying compatible with older HA versions

## Test plan
- [x] Reproduced the failure on HA Core 2026.9.0.dev with the original `boto3==1.37.1` pin (`Unable to install package boto3==1.37.1: No solution found when resolving dependencies`)
- [x] Applied this change locally, restarted HA Core, confirmed `llmvision` sets up without errors and all config entries load
- [ ] Not tested against the AWS Bedrock provider code path specifically (same caveat as noted in #703)

Fixes #703