### PR TITLE
fix: Increase maximum prompt size and prevent silent truncation

### DIFF
--- a/custom_components/llmvision/__init__.py
+++ b/custom_components/llmvision/__init__.py
@@ -40,6 +40,7 @@ from .const import (
     CONF_AWS_SECRET_ACCESS_KEY,
     CONF_AWS_REGION_NAME,
     MESSAGE,
+    MAX_MESSAGE_LENGTH,
     STORE_IN_TIMELINE,
     USE_MEMORY,
     MODEL,
@@ -450,7 +451,14 @@ class ServiceCallData:
         self.provider = str(data_call.data.get(PROVIDER))
         # If not set, the conf_default_model will be set in providers.py
         self.model = data_call.data.get(MODEL)
-        self.message = str(data_call.data.get(MESSAGE, "")[0:2000])
+        self.message = str(data_call.data.get(MESSAGE, ""))
+        if len(self.message) > MAX_MESSAGE_LENGTH:
+            _LOGGER.warning(
+                "Prompt is %d characters long and was truncated to %d characters",
+                len(self.message),
+                MAX_MESSAGE_LENGTH,
+            )
+            self.message = self.message[0:MAX_MESSAGE_LENGTH]
         self.store_in_timeline = data_call.data.get(STORE_IN_TIMELINE, False)
         self.use_memory = data_call.data.get(USE_MEMORY, False)
         self.image_paths = (

--- a/custom_components/llmvision/const.py
+++ b/custom_components/llmvision/const.py
@@ -55,6 +55,9 @@ SIGNAL_TIMELINE_UPDATED = f"{DOMAIN}_timeline_updated"
 
 # SERVICE CALL CONSTANTS
 MESSAGE = "message"
+# Maximum prompt length (characters) accepted from a service call.
+# Generous safety guard only; all supported providers accept far larger inputs.
+MAX_MESSAGE_LENGTH = 100000
 STORE_IN_TIMELINE = "store_in_timeline"
 USE_MEMORY = "use_memory"
 PROVIDER = "provider"


### PR DESCRIPTION
The message field of every analyzer service call was silently clipped to 2000 characters in ServiceCallData. The truncation happened without any log entry so long prompts lost their tail unnoticed. 

Additionally, the limit prevented more advanced prompts from being implemented. 

All tests passed and it was tested live on a running instance of HA.

Fixes #717 